### PR TITLE
3 프로젝트리워드 entity 생성

### DIFF
--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -16,6 +16,6 @@ public class ProjectService {
 
     @Transactional
     public ProjectInitResponse initProject(ProjectInitRequest request) {
-        return new ProjectInitResponse(projectRepository.save(request.toEntity()).getId());
+        return ProjectInitResponse.of(projectRepository.save(request.toEntity()).getId());
     }
 }

--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -1,0 +1,14 @@
+package kpl.fiml.project.application;
+
+import kpl.fiml.project.domain.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+}

--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -1,6 +1,8 @@
 package kpl.fiml.project.application;
 
 import kpl.fiml.project.domain.ProjectRepository;
+import kpl.fiml.project.dto.ProjectInitRequest;
+import kpl.fiml.project.dto.ProjectInitResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,4 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+
+    @Transactional
+    public ProjectInitResponse initProject(ProjectInitRequest request) {
+        return new ProjectInitResponse(projectRepository.save(request.toEntity()).getId());
+    }
 }

--- a/src/main/java/kpl/fiml/project/domain/Project.java
+++ b/src/main/java/kpl/fiml/project/domain/Project.java
@@ -84,7 +84,7 @@ public class Project {
         this.sharedCount = 0L;
         this.likedCount = 0L;
         this.sponsorCount = 0L;
-        this.status = ProjectStatus.PREPARING;
+        this.status = ProjectStatus.WRITING; // 초기 생성 시 리스트에 노출되지 않고 작성 중 상태로 생성
 
         this.projectImages = new ArrayList<>();
         this.rewards = new ArrayList<>();

--- a/src/main/java/kpl/fiml/project/domain/Project.java
+++ b/src/main/java/kpl/fiml/project/domain/Project.java
@@ -1,6 +1,7 @@
 package kpl.fiml.project.domain;
 
 import jakarta.persistence.*;
+import kpl.fiml.global.common.BaseEntity;
 import kpl.fiml.project.domain.enums.ProjectCategory;
 import kpl.fiml.project.domain.enums.ProjectStatus;
 import kpl.fiml.reward.domain.Reward;
@@ -17,7 +18,7 @@ import java.util.List;
 @Getter
 @Table(name = "projects")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Project {
+public class Project extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kpl/fiml/project/domain/Project.java
+++ b/src/main/java/kpl/fiml/project/domain/Project.java
@@ -1,0 +1,102 @@
+package kpl.fiml.project.domain;
+
+import jakarta.persistence.*;
+import kpl.fiml.project.domain.enums.ProjectCategory;
+import kpl.fiml.project.domain.enums.ProjectStatus;
+import kpl.fiml.reward.domain.Reward;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "projects")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // TODO: user_id 참조 외래키 추가
+
+    @Column(name = "title", length = 100)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "text")
+    private String content;
+
+    @Column(name = "summary", length = 200, nullable = false)
+    private String summary;
+
+    @Column(name = "goal_amount")
+    private Long goalAmount;
+
+    @Column(name = "current_amount", nullable = false)
+    private Long currentAmount;
+
+    @Column(name = "start_at", columnDefinition = "datetime")
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", columnDefinition = "datetime")
+    private LocalDateTime endAt;
+
+    @Column(name = "payment_at", columnDefinition = "datetime")
+    private LocalDateTime paymentAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private ProjectCategory category;
+
+    @Column(name = "commission_rate")
+    private Double commissionRate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ProjectStatus status;
+
+    @Column(name = "shared_count", nullable = false)
+    private Long sharedCount;
+
+    @Column(name = "liked_count", nullable = false)
+    private Long likedCount;
+
+    @Column(name = "sponsor_count", nullable = false)
+    private Long sponsorCount;
+
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<ProjectImage> projectImages;
+
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Reward> rewards;
+
+    @Builder
+    public Project(String summary, ProjectCategory category) {
+        this.summary = summary;
+        this.category = category;
+
+        this.currentAmount = 0L;
+        this.sharedCount = 0L;
+        this.likedCount = 0L;
+        this.sponsorCount = 0L;
+        this.status = ProjectStatus.PREPARING;
+
+        this.projectImages = new ArrayList<>();
+        this.rewards = new ArrayList<>();
+    }
+
+    public void addProjectImage(ProjectImage projectImage) {
+        this.projectImages.add(projectImage);
+        projectImage.setProject(this);
+    }
+
+    public void addReward(Reward reward) {
+        this.rewards.add(reward);
+        reward.setProject(this);
+    }
+}

--- a/src/main/java/kpl/fiml/project/domain/ProjectImage.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectImage.java
@@ -1,13 +1,14 @@
 package kpl.fiml.project.domain;
 
 import jakarta.persistence.*;
+import kpl.fiml.global.common.BaseEntity;
 import lombok.*;
 
 @Entity
 @Getter
 @Table(name = "project_images")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectImage {
+public class ProjectImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kpl/fiml/project/domain/ProjectImage.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectImage.java
@@ -1,0 +1,32 @@
+package kpl.fiml.project.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "project_images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+
+    @Column(name = "path", length = 100, nullable = false)
+    private String path;
+
+    @Builder
+    public ProjectImage(Integer sequence, String path) {
+        this.sequence = sequence;
+        this.path = path;
+    }
+}

--- a/src/main/java/kpl/fiml/project/domain/ProjectRepository.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectRepository.java
@@ -1,0 +1,8 @@
+package kpl.fiml.project.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/kpl/fiml/project/domain/enums/ProjectCategory.java
+++ b/src/main/java/kpl/fiml/project/domain/enums/ProjectCategory.java
@@ -1,0 +1,34 @@
+package kpl.fiml.project.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ProjectCategory {
+    BOARD_GAME("보드게임/TRPG"),
+    DIGITAL_GAME("디지털 게임"),
+    WEBTOON("웹툰/만화"),
+    WEBTOON_RESOURCES("웹툰 리소스"),
+    DESIGN_STATIONERY("디자인 문구"),
+    CHARACTER_GOODS("캐릭터/굿즈"),
+    HOME_LIVING("홈/리빙"),
+    TECH_APPLIANCES("테크/가전"),
+    PET("반려동물"),
+    FOOD("푸드"),
+    PERFUME_BEAUTY("향수/뷰티"),
+    CLOTHING("의류"),
+    ACCESSORIES("잡화"),
+    JEWELRY("주얼리"),
+    PUBLISHING("출판"),
+    DESIGN("디자인"),
+    ART("예술"),
+    PHOTOGRAPHY("사진"),
+    MUSIC("음악"),
+    MOVIE_VIDEO("영화/비디오"),
+    PERFORMANCE("공연");
+
+    private final String displayName;
+
+    ProjectCategory(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/kpl/fiml/project/domain/enums/ProjectStatus.java
+++ b/src/main/java/kpl/fiml/project/domain/enums/ProjectStatus.java
@@ -1,0 +1,19 @@
+package kpl.fiml.project.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ProjectStatus {
+
+    WRITING("작성 중"),
+    PREPARING("준비 중"),
+    PROCEEDING("진행 중"),
+    COMPLETE("완료"),
+    CANCEL("취소");
+
+    private final String displayName;
+
+    ProjectStatus(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectBasicInfoUpdateRequest.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectBasicInfoUpdateRequest.java
@@ -1,0 +1,15 @@
+package kpl.fiml.project.dto;
+
+import kpl.fiml.project.domain.enums.ProjectCategory;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProjectBasicInfoUpdateRequest {
+
+    private String summary;
+    private ProjectCategory category;
+    private String title;
+    private List<ProjectImageDto> projectImages;
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectContentUpdateRequest.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectContentUpdateRequest.java
@@ -1,0 +1,9 @@
+package kpl.fiml.project.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProjectContentUpdateRequest {
+
+    private String content;
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectFundingPlanUpdateRequest.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectFundingPlanUpdateRequest.java
@@ -1,0 +1,15 @@
+package kpl.fiml.project.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class ProjectFundingPlanUpdateRequest {
+
+    private Long goalAmount;
+    private LocalDateTime fundingStartAt;
+    private LocalDate fundingEndAt; // 시간은 23:59:59로 고정
+    private Double commissionRate;
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectImageDto.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectImageDto.java
@@ -1,0 +1,18 @@
+package kpl.fiml.project.dto;
+
+import kpl.fiml.project.domain.ProjectImage;
+import lombok.Getter;
+
+@Getter
+public class ProjectImageDto {
+
+    private Integer sequence;
+    private String path;
+
+    public ProjectImage toEntity() {
+        return ProjectImage.builder()
+                .sequence(sequence)
+                .path(path)
+                .build();
+    }
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectInitRequest.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectInitRequest.java
@@ -1,0 +1,19 @@
+package kpl.fiml.project.dto;
+
+import kpl.fiml.project.domain.Project;
+import kpl.fiml.project.domain.enums.ProjectCategory;
+import lombok.Getter;
+
+@Getter
+public class ProjectInitRequest {
+
+    private String summary;
+    private ProjectCategory category;
+
+    public Project toEntity() {
+        return Project.builder()
+                .summary(summary)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectInitResponse.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectInitResponse.java
@@ -1,11 +1,16 @@
 package kpl.fiml.project.dto;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectInitResponse {
 
     private final Long id;
+
+    public static ProjectInitResponse of(Long id) {
+        return new ProjectInitResponse(id);
+    }
 }

--- a/src/main/java/kpl/fiml/project/dto/ProjectInitResponse.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectInitResponse.java
@@ -1,0 +1,11 @@
+package kpl.fiml.project.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ProjectInitResponse {
+
+    private final Long id;
+}

--- a/src/main/java/kpl/fiml/project/presentation/ProjectController.java
+++ b/src/main/java/kpl/fiml/project/presentation/ProjectController.java
@@ -1,7 +1,13 @@
 package kpl.fiml.project.presentation;
 
 import kpl.fiml.project.application.ProjectService;
+import kpl.fiml.project.dto.ProjectInitRequest;
+import kpl.fiml.project.dto.ProjectInitResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProjectController {
 
     private final ProjectService projectService;
+
+    @PostMapping("/projects")
+    public ResponseEntity<ProjectInitResponse> initProject(@RequestBody ProjectInitRequest request) {
+        ProjectInitResponse response = this.projectService.initProject(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/src/main/java/kpl/fiml/project/presentation/ProjectController.java
+++ b/src/main/java/kpl/fiml/project/presentation/ProjectController.java
@@ -1,0 +1,14 @@
+package kpl.fiml.project.presentation;
+
+import kpl.fiml.project.application.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ProjectController {
+
+    private final ProjectService projectService;
+}

--- a/src/main/java/kpl/fiml/reward/application/RewardService.java
+++ b/src/main/java/kpl/fiml/reward/application/RewardService.java
@@ -1,0 +1,14 @@
+package kpl.fiml.reward.application;
+
+import kpl.fiml.reward.domain.RewardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RewardService {
+
+    private final RewardRepository rewardRepository;
+}

--- a/src/main/java/kpl/fiml/reward/domain/Reward.java
+++ b/src/main/java/kpl/fiml/reward/domain/Reward.java
@@ -1,0 +1,56 @@
+package kpl.fiml.reward.domain;
+
+import jakarta.persistence.*;
+import kpl.fiml.project.domain.Project;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "rewards")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reward {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @JoinColumn(name = "project_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Project project;
+
+    @Column(name = "title", length = 100, nullable = false)
+    private String title;
+
+    @Column(name = "content", columnDefinition = "text")
+    private String content;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Column(name = "remain_quantity", nullable = false)
+    private Integer remainQuantity;
+
+    @Column(name = "total_quantity", nullable = false)
+    private Integer totalQuantity;
+
+    @Column(name = "delivery_date", columnDefinition = "date", nullable = false)
+    private LocalDate deliveryDate;
+
+    @Column(name = "max_purchase_quantity", nullable = false)
+    private Integer maxPurchaseQuantity;
+
+    @Builder
+    public Reward(String title, String content, Long price, Integer totalQuantity, LocalDate deliveryDate, Integer maxPurchaseQuantity) {
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.totalQuantity = totalQuantity;
+        this.deliveryDate = deliveryDate;
+        this.maxPurchaseQuantity = maxPurchaseQuantity;
+
+        this.remainQuantity = totalQuantity;
+    }
+}

--- a/src/main/java/kpl/fiml/reward/domain/Reward.java
+++ b/src/main/java/kpl/fiml/reward/domain/Reward.java
@@ -1,6 +1,7 @@
 package kpl.fiml.reward.domain;
 
 import jakarta.persistence.*;
+import kpl.fiml.global.common.BaseEntity;
 import kpl.fiml.project.domain.Project;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import java.time.LocalDate;
 @Getter
 @Table(name = "rewards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Reward {
+public class Reward extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kpl/fiml/reward/domain/Reward.java
+++ b/src/main/java/kpl/fiml/reward/domain/Reward.java
@@ -27,6 +27,9 @@ public class Reward {
     @Column(name = "content", columnDefinition = "text")
     private String content;
 
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+
     @Column(name = "price", nullable = false)
     private Long price;
 
@@ -43,9 +46,10 @@ public class Reward {
     private Integer maxPurchaseQuantity;
 
     @Builder
-    public Reward(String title, String content, Long price, Integer totalQuantity, LocalDate deliveryDate, Integer maxPurchaseQuantity) {
+    public Reward(String title, String content, Integer sequence, Long price, Integer totalQuantity, LocalDate deliveryDate, Integer maxPurchaseQuantity) {
         this.title = title;
         this.content = content;
+        this.sequence = sequence;
         this.price = price;
         this.totalQuantity = totalQuantity;
         this.deliveryDate = deliveryDate;

--- a/src/main/java/kpl/fiml/reward/domain/RewardRepository.java
+++ b/src/main/java/kpl/fiml/reward/domain/RewardRepository.java
@@ -1,0 +1,8 @@
+package kpl.fiml.reward.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RewardRepository extends JpaRepository<Reward, Long> {
+}

--- a/src/main/java/kpl/fiml/reward/dto/RewardDto.java
+++ b/src/main/java/kpl/fiml/reward/dto/RewardDto.java
@@ -1,0 +1,30 @@
+package kpl.fiml.reward.dto;
+
+import kpl.fiml.reward.domain.Reward;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class RewardDto {
+
+    private String title;
+    private String content;
+    private Integer sequence;
+    private Long price;
+    private Integer quantity;
+    private LocalDate deliveryDate;
+    private Integer maxPurchaseQuantity;
+
+    public Reward toEntity() {
+        return Reward.builder()
+                .title(title)
+                .content(content)
+                .sequence(sequence)
+                .price(price)
+                .totalQuantity(quantity)
+                .deliveryDate(deliveryDate)
+                .maxPurchaseQuantity(maxPurchaseQuantity)
+                .build();
+    }
+}

--- a/src/main/java/kpl/fiml/reward/dto/RewardUpdateRequest.java
+++ b/src/main/java/kpl/fiml/reward/dto/RewardUpdateRequest.java
@@ -1,0 +1,18 @@
+package kpl.fiml.reward.dto;
+
+import kpl.fiml.reward.domain.Reward;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RewardUpdateRequest {
+
+    private List<RewardDto> rewards;
+
+    public List<Reward> toEntities() {
+        return rewards.stream()
+                .map(RewardDto::toEntity)
+                .toList();
+    }
+}

--- a/src/main/java/kpl/fiml/reward/presentation/RewardController.java
+++ b/src/main/java/kpl/fiml/reward/presentation/RewardController.java
@@ -1,0 +1,14 @@
+package kpl.fiml.reward.presentation;
+
+import kpl.fiml.reward.application.RewardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class RewardController {
+
+    private final RewardService rewardService;
+}


### PR DESCRIPTION
프로젝트 관련 Entity와 Request DTO, 그리고 프로젝트 초기화 API만 작성하였습니다.

## Entity 및 Enum 설명

ProjectEntity
- OneToMany List 관계설정: project 조회 시 대부분의 경우 같이 조회할 것으로 예상되어 미리 설정
- commissionRate: 요금제 선택 대신 프로젝트의 수수료율 정책만 남김
- 그 외 기본 정보 및 펀딩 계획 내용: 도메인을 표현할 수 있는 필수적인 내용만 남기고 나머지 간소화
- nullable 기준: 텀블벅에서 프로젝트 첫 생성 시 카테고리와 요약 값만 받고 생성하여 두 값에 대해서만 nullable=false 설정

RewardEntity
- Item 기능 삭제: Item 테이블을 별도로 생성하지 않고 content에서 표현하는 것으로 간소화

ProjectCategoryEntity
- 카테고리명 기준: 실제 텀블벅에 존재하는 카테고리들로 생성

ProjectStatus
- 작성 중: 프로젝트 업로드 전
- 준비 중: 펀딩 시작 전
- 진행 중: 펀딩 시작 후 진행 중
- 완료: 펀딩 기간 종료
- 취소: 창작자에 의한 펀딩 취소

## 각 Request DTO의 역할

- ProjectInitRequest: 프로젝트 초기 생성
- ProjectBasicInfoUpdateRequest: 프로젝트 기본 정보 수정
- ProjectContentUpdateRequest: 프로젝트 소개 내용 수정
- ProjectFundingPlanUpdateRequest: 프로젝트 펀딩 계획 수정
- RewardUpdateRequest: 프로젝트 리워드 수정