### PR TITLE
19 project 조회 관련 api 작성 및 querydsl 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,6 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij,macos,windows,visualstudiocode,gradle
 
 src/main/resources/application.yaml
+
+# Querydsl
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/kpl/fiml/global/config/QueryDslConfig.java
+++ b/src/main/java/kpl/fiml/global/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package kpl.fiml.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/kpl/fiml/global/dto/PageResponse.java
+++ b/src/main/java/kpl/fiml/global/dto/PageResponse.java
@@ -13,8 +13,8 @@ public class PageResponse<T, R> {
         private final int totalPages;
         private final long totalElements;
 
-        public PageResponse(Page<T> pageResponse, Function<T, R> function) {
-            this.content = pageResponse.getContent().stream().map(function).toList();
+        public PageResponse(Page<T> pageResponse, Function<T, R> converter) {
+            this.content = pageResponse.getContent().stream().map(converter).toList();
             this.totalPages = pageResponse.getTotalPages();
             this.totalElements = pageResponse.getTotalElements();
         }

--- a/src/main/java/kpl/fiml/global/dto/PageResponse.java
+++ b/src/main/java/kpl/fiml/global/dto/PageResponse.java
@@ -1,0 +1,21 @@
+package kpl.fiml.global.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Getter
+public class PageResponse<T, R> {
+
+        private final List<R> content;
+        private final int totalPages;
+        private final long totalElements;
+
+        public PageResponse(Page<T> pageResponse, Function<T, R> function) {
+            this.content = pageResponse.getContent().stream().map(function).toList();
+            this.totalPages = pageResponse.getTotalPages();
+            this.totalElements = pageResponse.getTotalElements();
+        }
+}

--- a/src/main/java/kpl/fiml/global/dto/PageResponse.java
+++ b/src/main/java/kpl/fiml/global/dto/PageResponse.java
@@ -13,9 +13,13 @@ public class PageResponse<T, R> {
         private final int totalPages;
         private final long totalElements;
 
-        public PageResponse(Page<T> pageResponse, Function<T, R> converter) {
+        private PageResponse(Page<T> pageResponse, Function<T, R> converter) {
             this.content = pageResponse.getContent().stream().map(converter).toList();
             this.totalPages = pageResponse.getTotalPages();
             this.totalElements = pageResponse.getTotalElements();
+        }
+
+        public static <T, R> PageResponse<T, R> of(Page<T> pageResponse, Function<T, R> converter) {
+            return new PageResponse<>(pageResponse, converter);
         }
 }

--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -1,9 +1,11 @@
 package kpl.fiml.project.application;
 
+import kpl.fiml.global.dto.PageResponse;
 import kpl.fiml.project.domain.Project;
 import kpl.fiml.project.domain.ProjectRepository;
 import kpl.fiml.project.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,6 +59,12 @@ public class ProjectService {
     public void submitProject(Long projectId) {
         this.getProjectById(projectId)
                 .submit();
+    }
+
+    public PageResponse<Project, ProjectDto> findProjectsBySearchConditions(ProjectListFindRequest request) {
+        return new PageResponse<>(
+                projectRepository.findWithSearchKeyword(request, PageRequest.of(request.getPage(), request.getSize())), ProjectDto::of
+        );
     }
 
     private Project getProjectById(Long projectId) {

--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -62,7 +62,7 @@ public class ProjectService {
     }
 
     public PageResponse<Project, ProjectDto> findProjectsBySearchConditions(ProjectListFindRequest request) {
-        return new PageResponse<>(
+        return PageResponse.of(
                 projectRepository.findWithSearchKeyword(request, PageRequest.of(request.getPage(), request.getSize())), ProjectDto::of
         );
     }

--- a/src/main/java/kpl/fiml/project/domain/Project.java
+++ b/src/main/java/kpl/fiml/project/domain/Project.java
@@ -25,7 +25,8 @@ public class Project extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    // TODO: optional = false로 변경
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/kpl/fiml/project/domain/ProjectRepository.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryQuery {
     List<Project> findAllByStatus(ProjectStatus status);
 }

--- a/src/main/java/kpl/fiml/project/domain/ProjectRepositoryQuery.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectRepositoryQuery.java
@@ -1,0 +1,10 @@
+package kpl.fiml.project.domain;
+
+import kpl.fiml.project.dto.ProjectListFindRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProjectRepositoryQuery {
+
+    Page<Project> findWithSearchKeyword(ProjectListFindRequest searchRequest, Pageable pageable);
+}

--- a/src/main/java/kpl/fiml/project/domain/ProjectRepositoryQueryImpl.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectRepositoryQueryImpl.java
@@ -1,0 +1,94 @@
+package kpl.fiml.project.domain;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kpl.fiml.project.domain.enums.ProjectCategory;
+import kpl.fiml.project.domain.enums.ProjectStatus;
+import kpl.fiml.project.dto.ProjectListFindRequest;
+import kpl.fiml.project.dto.ProjectListFindRequest.SortField;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static kpl.fiml.project.domain.QProject.project;
+
+@RequiredArgsConstructor
+public class ProjectRepositoryQueryImpl implements ProjectRepositoryQuery {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Project> findWithSearchKeyword(ProjectListFindRequest searchRequest, Pageable pageable) {
+        BooleanExpression expression = titleContainsIgnoreCase(searchRequest.getSearchKeyword())
+                .and(projectStatusEq(searchRequest.getStatus()))
+                .and(project.status.ne(ProjectStatus.WRITING))
+                .and(projectCategoryEq(searchRequest.getCategory()));
+
+        List<Project> projects = jpaQueryFactory
+                .selectFrom(project)
+                .where(expression)
+                .orderBy(getOrderSpecifier(searchRequest.getSortField(), searchRequest.getSortDirection()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Project> countQuery = jpaQueryFactory
+                .selectFrom(project)
+                .where(expression);
+
+        return PageableExecutionUtils.getPage(projects, pageable, countQuery::fetchCount);
+    }
+
+    private BooleanExpression titleContainsIgnoreCase(String keyword) {
+        return project.title.containsIgnoreCase(keyword);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(SortField sortField, Direction sortDirection) {
+        if (sortField == SortField.POPULAR) {
+            return sortDirection == Direction.ASC
+                    ? project.likedCount.asc()
+                    : project.likedCount.desc();
+        } else if (sortField == SortField.START_DATE) {
+            return sortDirection == Direction.ASC
+                    ? project.startAt.asc()
+                    : project.startAt.desc();
+        } else if (sortField == SortField.END_DATE) {
+            return sortDirection == Direction.ASC
+                    ? project.endAt.asc()
+                    : project.endAt.desc();
+        }
+
+        return null;
+    }
+
+    private BooleanExpression projectStatusEq(ProjectListFindRequest.Status status) {
+        if (status == ProjectListFindRequest.Status.PREPARING) {
+            return project.status.eq(ProjectStatus.PREPARING);
+        } else if (status == ProjectListFindRequest.Status.PROCEEDING) {
+            return project.status.eq(ProjectStatus.PROCEEDING);
+        } else if (status == ProjectListFindRequest.Status.COMPLETE) {
+            return project.status.eq(ProjectStatus.FUNDING_COMPLETE)
+                    .or(project.status.eq(ProjectStatus.SETTLEMENT_COMPLETE));
+        } else if (status == ProjectListFindRequest.Status.CANCEL) {
+            return project.status.eq(ProjectStatus.CANCEL);
+        }
+
+        return null;
+    }
+
+    private BooleanExpression projectCategoryEq(ProjectCategory category) {
+        if (category != null) {
+            return project.category.eq(category);
+        }
+
+        return null;
+    }
+
+    // TODO: AchieveRate 검색 조건 추가
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectDto.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectDto.java
@@ -1,0 +1,27 @@
+package kpl.fiml.project.dto;
+
+import kpl.fiml.project.domain.Project;
+import lombok.Getter;
+
+// TODO: 필요한 값 추가
+@Getter
+public class ProjectDto {
+
+    private final Long id;
+    private final String title;
+    private final String summary;
+    private final Long goalAmount;
+    private final Long currentAmount;
+
+    private ProjectDto(Project project) {
+        this.id = project.getId();
+        this.title = project.getTitle();
+        this.summary = project.getSummary();
+        this.goalAmount = project.getGoalAmount();
+        this.currentAmount = project.getCurrentAmount();
+    }
+
+    public static ProjectDto of(Project project) {
+        return new ProjectDto(project);
+    }
+}

--- a/src/main/java/kpl/fiml/project/dto/ProjectListFindRequest.java
+++ b/src/main/java/kpl/fiml/project/dto/ProjectListFindRequest.java
@@ -1,0 +1,49 @@
+package kpl.fiml.project.dto;
+
+import kpl.fiml.project.domain.enums.ProjectCategory;
+import lombok.*;
+import org.springframework.data.domain.Sort.Direction;
+
+@Getter
+@AllArgsConstructor
+public class ProjectListFindRequest {
+
+    private Integer page;
+    private Integer size;
+    private String searchKeyword;
+    private Status status;
+    // TODO: 0 - 100 사이의 정수
+    private int minAchieveRate;
+    // TODO: 0 - 100 사이의 정수
+    private int maxAchieveRate;
+    private SortField sortField;
+    private Direction sortDirection;
+    private ProjectCategory category;
+
+    @Getter
+    public enum SortField {
+        START_DATE("startDate"),
+        END_DATE("endDate"),
+        POPULAR("popular");
+
+        private final String field;
+
+        SortField(String field) {
+            this.field = field;
+        }
+    }
+
+    @Getter
+    public enum Status {
+        PREPARING("준비 중"),
+        PROCEEDING("진행 중"),
+        COMPLETE("완료"),
+        CANCEL("취소");
+
+        private final String displayName;
+
+        Status(String displayName) {
+            this.displayName = displayName;
+        }
+    }
+}

--- a/src/main/java/kpl/fiml/project/presentation/ProjectController.java
+++ b/src/main/java/kpl/fiml/project/presentation/ProjectController.java
@@ -1,6 +1,8 @@
 package kpl.fiml.project.presentation;
 
+import kpl.fiml.global.dto.PageResponse;
 import kpl.fiml.project.application.ProjectService;
+import kpl.fiml.project.domain.Project;
 import kpl.fiml.project.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -58,5 +60,12 @@ public class ProjectController {
         this.projectService.submitProject(projectId);
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/projects")
+    public ResponseEntity<PageResponse<Project, ProjectDto>> findProjects(@ModelAttribute ProjectListFindRequest request) {
+        PageResponse<Project, ProjectDto> projectsBySearchConditions = this.projectService.findProjectsBySearchConditions(request);
+
+        return ResponseEntity.ok(projectsBySearchConditions);
     }
 }


### PR DESCRIPTION
텀이 길어진 것 같아 우선 전체적인 틀을 잡아둔 상태로 PR 요청 보냅니다!
아직 미구현 된 아래 부분은 다음 PR에 완료할 예정입니다.

- 프로젝트 달성율 계산 서브 쿼리
- Project - User 연관 관계 null 임시 허용 해제
- 그 외 더 필요한 반환 값
  - 썸네일 사진(프로젝트 첫 번째 이미지)
  - 카테고리(+카테고리 표시 이름)
  - 창작자
  - 프로젝트 상태
  - 달성율
  - 현재 후원 금액
  - 목표 후원 금액
  - 프로젝트 남은 기간