### PR TITLE
26 후원 생성삭제 api 구현

### DIFF
--- a/src/main/java/kpl/fiml/payment/application/PaymentService.java
+++ b/src/main/java/kpl/fiml/payment/application/PaymentService.java
@@ -49,6 +49,15 @@ public class PaymentService {
         paymentRepository.save(request.toEntity(LocalDateTime.of(request.getRequestedDay().plusDays(NEXT_PAYMENT_OFFSET), LocalTime.of(PAYMENT_PERIOD_HOUR, PAYMENT_PERIOD_MINUTE))));
     }
 
+    @Transactional
+    public void deletePayments(Sponsor sponsor) {
+        List<Payment> payments = paymentRepository.findAllBySponsor(sponsor);
+
+        for (Payment payment : payments) {
+            payment.delete();
+        }
+    }
+
     @Scheduled(cron = "0 0 14 * * *", zone = "Asia/Seoul")
     @Transactional
     public void tryPay() {

--- a/src/main/java/kpl/fiml/payment/application/PaymentService.java
+++ b/src/main/java/kpl/fiml/payment/application/PaymentService.java
@@ -3,6 +3,7 @@ package kpl.fiml.payment.application;
 import kpl.fiml.payment.domain.Payment;
 import kpl.fiml.payment.domain.PaymentRepository;
 import kpl.fiml.payment.domain.PaymentStatus;
+import kpl.fiml.payment.dto.PaymentCreateRequest;
 import kpl.fiml.payment.dto.PaymentDto;
 import kpl.fiml.sponsor.domain.Sponsor;
 import kpl.fiml.sponsor.domain.SponsorRepository;
@@ -43,6 +44,11 @@ public class PaymentService {
         return responses;
     }
 
+    @Transactional
+    public void createPayment(PaymentCreateRequest request) {
+        paymentRepository.save(request.toEntity(LocalDateTime.of(request.getRequestedDay().plusDays(NEXT_PAYMENT_OFFSET), LocalTime.of(PAYMENT_PERIOD_HOUR, PAYMENT_PERIOD_MINUTE))));
+    }
+
     @Scheduled(cron = "0 0 14 * * *", zone = "Asia/Seoul")
     @Transactional
     public void tryPay() {
@@ -64,10 +70,7 @@ public class PaymentService {
                 if (paymentRepository.countBySponsor(sponsor) == MAX_PAYMENT_TRIAL) {
                     sponsor.paymentFail();
                 } else {
-                    paymentRepository.save(Payment.builder()
-                            .sponsor(sponsor)
-                            .requestedAt(LocalDateTime.of(LocalDate.now().plusDays(NEXT_PAYMENT_OFFSET), LocalTime.of(PAYMENT_PERIOD_HOUR, PAYMENT_PERIOD_MINUTE)))
-                            .build());
+                    createPayment(PaymentCreateRequest.of(sponsor, LocalDate.now()));
                     sponsor.updateStatusToPaymentProceeding();
                 }
             }

--- a/src/main/java/kpl/fiml/payment/application/PaymentService.java
+++ b/src/main/java/kpl/fiml/payment/application/PaymentService.java
@@ -90,6 +90,7 @@ public class PaymentService {
     private List<Payment> getRequiredPayments() {
         return paymentRepository.findAllByStatus(PaymentStatus.WAIT)
                 .stream()
+                .filter(payment -> !payment.isDeleted())
                 .filter(payment ->
                         payment.getRequestedAt().isEqual(LocalDateTime.now()) || payment.getRequestedAt().isBefore(LocalDateTime.now())
                 )

--- a/src/main/java/kpl/fiml/payment/dto/PaymentCreateRequest.java
+++ b/src/main/java/kpl/fiml/payment/dto/PaymentCreateRequest.java
@@ -1,0 +1,29 @@
+package kpl.fiml.payment.dto;
+
+import kpl.fiml.payment.domain.Payment;
+import kpl.fiml.sponsor.domain.Sponsor;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentCreateRequest {
+
+    private final Sponsor sponsor;
+    private final LocalDate requestedDay;
+
+    public static PaymentCreateRequest of(Sponsor sponsor, LocalDate requestedDay) {
+        return new PaymentCreateRequest(sponsor, requestedDay);
+    }
+
+    public Payment toEntity(LocalDateTime requestedAt) {
+        return Payment.builder()
+                .sponsor(sponsor)
+                .requestedAt(requestedAt)
+                .build();
+    }
+}

--- a/src/main/java/kpl/fiml/project/domain/Project.java
+++ b/src/main/java/kpl/fiml/project/domain/Project.java
@@ -167,7 +167,12 @@ public class Project extends BaseEntity {
         }
     }
 
-    public void updateSponsorInfo(Long paymentFailAmount) {
+    public void updateSponsorAddInfo(Long paymentAddAmount) {
+        this.currentAmount += paymentAddAmount;
+        this.sponsorCount++;
+    }
+
+    public void updateSponsorDeleteInfo(Long paymentFailAmount) {
         this.currentAmount -= paymentFailAmount;
         this.sponsorCount--;
     }

--- a/src/main/java/kpl/fiml/project/domain/Reward.java
+++ b/src/main/java/kpl/fiml/project/domain/Reward.java
@@ -57,4 +57,8 @@ public class Reward extends BaseEntity {
 
         this.remainQuantity = totalQuantity;
     }
+
+    public boolean checkUnderflowPrice(Long amount) {
+        return price > amount;
+    }
 }

--- a/src/main/java/kpl/fiml/project/domain/RewardRepository.java
+++ b/src/main/java/kpl/fiml/project/domain/RewardRepository.java
@@ -3,6 +3,9 @@ package kpl.fiml.project.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RewardRepository extends JpaRepository<Reward, Long> {
+    List<Reward> findAllByProject(Project project);
 }

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -9,11 +9,13 @@ import kpl.fiml.sponsor.domain.Sponsor;
 import kpl.fiml.sponsor.domain.SponsorRepository;
 import kpl.fiml.sponsor.dto.SponsorCreateRequest;
 import kpl.fiml.sponsor.dto.SponsorCreateResponse;
+import kpl.fiml.sponsor.dto.SponsorDeleteResponse;
 import kpl.fiml.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -40,7 +42,22 @@ public class SponsorService {
     }
 
     @Transactional
-    public void deleteSponsors(Project project) {
+    public SponsorDeleteResponse deleteSponsorByUser(Long sponsorId, User user) {
+        Sponsor sponsor = sponsorRepository.findByIdAndUser(sponsorId, user)
+                .filter(uncheckedSponsor -> !uncheckedSponsor.isDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 후원이 존재하지 않습니다."));
+
+        if (sponsor.getReward().getProject().getEndAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("펀딩이 종료된 후에는 후원 취소가 불가합니다.");
+        }
+
+        sponsor.delete();
+
+        return SponsorDeleteResponse.of(sponsor.getId(), sponsor.getDeletedAt());
+    }
+
+    @Transactional
+    public void deleteSponsorsByProject(Project project) {
         List<Reward> rewards = rewardRepository.findAllByProject(project);
 
         for (Reward reward : rewards) {

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -35,8 +35,8 @@ public class SponsorService {
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 리워드가 존재하지 않습니다."));
 
         Sponsor sponsor = sponsorRepository.save(request.toEntity(user, reward));
-        reward.getProject().updateSponsorAddInfo(sponsor.getTotalAmount());
 
+        reward.getProject().updateSponsorAddInfo(sponsor.getTotalAmount());
         paymentService.createPayment(PaymentCreateRequest.of(sponsor, reward.getProject().getEndAt().toLocalDate()));
 
         return SponsorCreateResponse.of(sponsor.getId());

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -35,6 +35,7 @@ public class SponsorService {
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 리워드가 존재하지 않습니다."));
 
         Sponsor sponsor = sponsorRepository.save(request.toEntity(user, reward));
+        reward.getProject().updateSponsorAddInfo(sponsor.getTotalAmount());
 
         paymentService.createPayment(PaymentCreateRequest.of(sponsor, reward.getProject().getEndAt().toLocalDate()));
 

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -2,6 +2,7 @@ package kpl.fiml.sponsor.application;
 
 import kpl.fiml.payment.application.PaymentService;
 import kpl.fiml.payment.dto.PaymentCreateRequest;
+import kpl.fiml.project.domain.Project;
 import kpl.fiml.project.domain.Reward;
 import kpl.fiml.project.domain.RewardRepository;
 import kpl.fiml.sponsor.domain.Sponsor;
@@ -12,6 +13,8 @@ import kpl.fiml.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,5 +37,19 @@ public class SponsorService {
         paymentService.createPayment(PaymentCreateRequest.of(sponsor, reward.getProject().getEndAt().toLocalDate()));
 
         return SponsorCreateResponse.of(sponsor.getId());
+    }
+
+    @Transactional
+    public void deleteSponsors(Project project) {
+        List<Reward> rewards = rewardRepository.findAllByProject(project);
+
+        for (Reward reward : rewards) {
+            List<Sponsor> sponsors = sponsorRepository.findAllByReward(reward);
+
+            for (Sponsor sponsor : sponsors) {
+                paymentService.deletePayments(sponsor);
+                sponsor.delete();
+            }
+        }
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -48,6 +48,7 @@ public class SponsorService {
 
             for (Sponsor sponsor : sponsors) {
                 paymentService.deletePayments(sponsor);
+                sponsor.updateStatusToFundingFail();
                 sponsor.delete();
             }
         }

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -44,9 +44,7 @@ public class SponsorService {
 
     @Transactional
     public SponsorDeleteResponse deleteSponsorByUser(Long sponsorId, User user) {
-        Sponsor sponsor = sponsorRepository.findByIdAndUser(sponsorId, user)
-                .filter(uncheckedSponsor -> !uncheckedSponsor.isDeleted())
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 후원이 존재하지 않습니다."));
+        Sponsor sponsor = getByIdAndUser(sponsorId, user);
 
         if (sponsor.getReward().getProject().getEndAt().isBefore(LocalDateTime.now())) {
             throw new IllegalArgumentException("펀딩이 종료된 후에는 후원 취소가 불가합니다.");
@@ -70,5 +68,12 @@ public class SponsorService {
                 sponsor.delete();
             }
         }
+    }
+
+    private Sponsor getByIdAndUser(Long sponsorId, User user) {
+        return sponsorRepository.findById(sponsorId)
+                .filter(uncheckedSponsor -> uncheckedSponsor.getUser().equals(user))
+                .filter(uncheckedSponsor -> !uncheckedSponsor.isDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 후원이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -1,6 +1,14 @@
 package kpl.fiml.sponsor.application;
 
+import kpl.fiml.payment.application.PaymentService;
+import kpl.fiml.payment.dto.PaymentCreateRequest;
+import kpl.fiml.project.domain.Reward;
+import kpl.fiml.project.domain.RewardRepository;
+import kpl.fiml.sponsor.domain.Sponsor;
 import kpl.fiml.sponsor.domain.SponsorRepository;
+import kpl.fiml.sponsor.dto.SponsorCreateRequest;
+import kpl.fiml.sponsor.dto.SponsorCreateResponse;
+import kpl.fiml.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,5 +18,21 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SponsorService {
 
+    private final PaymentService paymentService;
+
     private final SponsorRepository sponsorRepository;
+    private final RewardRepository rewardRepository;
+
+    @Transactional
+    public SponsorCreateResponse createSponsor(SponsorCreateRequest request, User user) {
+        Reward reward = rewardRepository.findById(request.getRewardId())
+                .filter(uncheckedReward -> !uncheckedReward.isDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 리워드가 존재하지 않습니다."));
+
+        Sponsor sponsor = sponsorRepository.save(request.toEntity(user, reward));
+
+        paymentService.createPayment(PaymentCreateRequest.of(sponsor, reward.getProject().getEndAt().toLocalDate()));
+
+        return SponsorCreateResponse.of(sponsor.getId());
+    }
 }

--- a/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
@@ -63,7 +63,7 @@ public class Sponsor extends BaseEntity {
     }
 
     private void validateTotalAmount(Reward reward, Long totalAmount) {
-        if (reward.getPrice() > totalAmount) {
+        if (reward.checkUnderflowPrice(totalAmount)) {
             throw new IllegalArgumentException("후원 금액이 리워드 가격보다 적습니다.");
         }
     }

--- a/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
@@ -57,6 +57,6 @@ public class Sponsor extends BaseEntity {
 
     public void paymentFail() {
         this.status = SponsorStatus.PAYMENT_FAIL;
-        this.reward.getProject().updateSponsorInfo(this.totalAmount);
+        this.reward.getProject().updateSponsorDeleteInfo(this.totalAmount);
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
@@ -36,6 +36,8 @@ public class Sponsor extends BaseEntity {
 
     @Builder
     public Sponsor(User user, Reward reward, Long totalAmount) {
+        validateTotalAmount(reward, totalAmount);
+
         this.user = user;
         this.reward = reward;
         this.totalAmount = totalAmount;
@@ -58,5 +60,11 @@ public class Sponsor extends BaseEntity {
     public void paymentFail() {
         this.status = SponsorStatus.PAYMENT_FAIL;
         this.reward.getProject().updateSponsorDeleteInfo(this.totalAmount);
+    }
+
+    private void validateTotalAmount(Reward reward, Long totalAmount) {
+        if (reward.getPrice() > totalAmount) {
+            throw new IllegalArgumentException("후원 금액이 리워드 가격보다 적습니다.");
+        }
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/domain/SponsorRepository.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/SponsorRepository.java
@@ -1,15 +1,12 @@
 package kpl.fiml.sponsor.domain;
 
 import kpl.fiml.project.domain.Reward;
-import kpl.fiml.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface SponsorRepository extends JpaRepository<Sponsor, Long> {
-    Optional<Sponsor> findByIdAndUser(Long id, User user);
     List<Sponsor> findAllByReward(Reward reward);
 }

--- a/src/main/java/kpl/fiml/sponsor/domain/SponsorRepository.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/SponsorRepository.java
@@ -1,8 +1,12 @@
 package kpl.fiml.sponsor.domain;
 
+import kpl.fiml.project.domain.Reward;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SponsorRepository extends JpaRepository<Sponsor, Long> {
+    List<Sponsor> findAllByReward(Reward reward);
 }

--- a/src/main/java/kpl/fiml/sponsor/domain/SponsorRepository.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/SponsorRepository.java
@@ -1,12 +1,15 @@
 package kpl.fiml.sponsor.domain;
 
 import kpl.fiml.project.domain.Reward;
+import kpl.fiml.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SponsorRepository extends JpaRepository<Sponsor, Long> {
+    Optional<Sponsor> findByIdAndUser(Long id, User user);
     List<Sponsor> findAllByReward(Reward reward);
 }

--- a/src/main/java/kpl/fiml/sponsor/dto/SponsorCreateRequest.java
+++ b/src/main/java/kpl/fiml/sponsor/dto/SponsorCreateRequest.java
@@ -1,0 +1,21 @@
+package kpl.fiml.sponsor.dto;
+
+import kpl.fiml.project.domain.Reward;
+import kpl.fiml.sponsor.domain.Sponsor;
+import kpl.fiml.user.domain.User;
+import lombok.Getter;
+
+@Getter
+public class SponsorCreateRequest {
+
+    private Long rewardId;
+    private Long totalAmount;
+
+    public Sponsor toEntity(User user, Reward reward) {
+        return Sponsor.builder()
+                .user(user)
+                .reward(reward)
+                .totalAmount(totalAmount)
+                .build();
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/dto/SponsorCreateResponse.java
+++ b/src/main/java/kpl/fiml/sponsor/dto/SponsorCreateResponse.java
@@ -1,0 +1,16 @@
+package kpl.fiml.sponsor.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SponsorCreateResponse {
+
+    private final Long id;
+
+    public static SponsorCreateResponse of(Long id) {
+        return new SponsorCreateResponse(id);
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/dto/SponsorDeleteResponse.java
+++ b/src/main/java/kpl/fiml/sponsor/dto/SponsorDeleteResponse.java
@@ -1,0 +1,19 @@
+package kpl.fiml.sponsor.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SponsorDeleteResponse {
+
+    private final Long id;
+    private final LocalDateTime deleteAt;
+
+    public static SponsorDeleteResponse of(Long id, LocalDateTime deleteAt) {
+        return new SponsorDeleteResponse(id, deleteAt);
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/presentation/SponsorController.java
+++ b/src/main/java/kpl/fiml/sponsor/presentation/SponsorController.java
@@ -3,6 +3,7 @@ package kpl.fiml.sponsor.presentation;
 import kpl.fiml.sponsor.application.SponsorService;
 import kpl.fiml.sponsor.dto.SponsorCreateRequest;
 import kpl.fiml.sponsor.dto.SponsorCreateResponse;
+import kpl.fiml.sponsor.dto.SponsorDeleteResponse;
 import kpl.fiml.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,5 +23,12 @@ public class SponsorController {
         SponsorCreateResponse response = sponsorService.createSponsor(request, user);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/sponsors/{sponsorId}")
+    public ResponseEntity<SponsorDeleteResponse> deleteSponsor(@PathVariable Long sponsorId, @AuthenticationPrincipal User user) {
+        SponsorDeleteResponse response = sponsorService.deleteSponsorByUser(sponsorId, user);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/presentation/SponsorController.java
+++ b/src/main/java/kpl/fiml/sponsor/presentation/SponsorController.java
@@ -1,9 +1,14 @@
 package kpl.fiml.sponsor.presentation;
 
 import kpl.fiml.sponsor.application.SponsorService;
+import kpl.fiml.sponsor.dto.SponsorCreateRequest;
+import kpl.fiml.sponsor.dto.SponsorCreateResponse;
+import kpl.fiml.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,4 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SponsorController {
 
     private final SponsorService sponsorService;
+
+    @PostMapping("/sponsors")
+    public ResponseEntity<SponsorCreateResponse> createSponsor(@RequestBody SponsorCreateRequest request, @AuthenticationPrincipal User user) {
+        SponsorCreateResponse response = sponsorService.createSponsor(request, user);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }


### PR DESCRIPTION
- PaymentService에 Payment 생성하는 createPayment 메서드 추가
  - 후원 정보 생성 시 동시에 최초 결제 정보를 생성하는데, tryPay에서 결제 실패 시 Payment 생성하는 로직과 비슷하여 아예 createPayment로 메서드를 따로 생성하였습니다.

- PaymentService에 Payment 삭제하는 deletePayments 메서드 추가
  - 펀딩 실패 시 후원 정보 삭제함과 동시에 결제 정보들도 삭제하도록 메서드 생성하였고, tryPay에서 결제 필요한 Payment 리스트 조회 시 삭제한 Payment는 제외하도록 로직 추가하였습니다.

- createSponsor
  - 프로젝트에 추가된 후원 금액/인원 반영, 후원 종료 다음날로 최초 결제 요청 정보 생성

- deleteSponsorByUser
  - 후원자 요청으로 후원 취소하는 메서드
  - 펀딩 종료 전까지 후원 취소 가능
  - 취소를 요청하는 사용자와 Sponsor의 후원자가 일치하는지 확인하는 로직이 있습니다. 정산/결제 조회 시에도 이러한 로직이 있으면 좋을 것 같아 추후 추가하려고 합니다.

- deleteSponsorsByProject
  - 펀딩 실패 시 모든 후원 리스트 조회하여 취소하는 메서드
  - 이 경우, ProjectStatus가 FUNDING_FAILURE가 될 때 서비스 내부에서 호출될 비즈니스 로직이라고 생각하여 Controller에 api 추가하지 않았습니다.

[후원을 변경하거나 취소할 수 있나요?](https://help.tumblbug.com/hc/ko/articles/115006479408--%ED%9B%84%EC%9B%90-%ED%9B%84%EC%9B%90%EC%9D%84-%EB%B3%80%EA%B2%BD%ED%95%98%EA%B1%B0%EB%82%98-%EC%B7%A8%EC%86%8C%ED%95%A0-%EC%88%98-%EC%9E%88%EB%82%98%EC%9A%94-)를 참고하였으며, 참고한 글에 따라 펀딩 종료 전까지는 후원 변경도 가능한 것으로 보입니다. 후원 조회와 함께 구현하도록 하겠습니다~