### PR TITLE
36 팔로우 찜 기능 추가

### DIFF
--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -97,6 +97,21 @@ public class ProjectService {
                 });
     }
 
+    @Transactional
+    public void unlikeProject(Long projectId, Long id) {
+        Project project = getProjectById(projectId);
+        User user = userService.getById(id);
+
+        ProjectLike projectLike = getByProjectAndUser(project, user);
+
+        projectLikeRepository.delete(projectLike);
+    }
+
+    private ProjectLike getByProjectAndUser(Project project, User user) {
+        return projectLikeRepository.findByProjectAndUser(project, user)
+                .orElseThrow(() -> new IllegalArgumentException("좋아요를 누르지 않은 프로젝트입니다."));
+    }
+
     private Project getProjectById(Long projectId) {
         return projectRepository.findById(projectId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로젝트입니다."));

--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -2,8 +2,11 @@ package kpl.fiml.project.application;
 
 import kpl.fiml.global.dto.PageResponse;
 import kpl.fiml.project.domain.Project;
+import kpl.fiml.project.domain.ProjectLike;
+import kpl.fiml.project.domain.ProjectLikeRepository;
 import kpl.fiml.project.domain.ProjectRepository;
 import kpl.fiml.project.dto.*;
+import kpl.fiml.user.application.UserService;
 import kpl.fiml.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final ProjectLikeRepository projectLikeRepository;
+    private final UserService userService;
 
     @Transactional
     public ProjectInitResponse initProject(ProjectInitRequest request, User user) {
@@ -68,6 +73,28 @@ public class ProjectService {
         return PageResponse.of(
                 projectRepository.findWithSearchKeyword(request, PageRequest.of(request.getPage(), request.getSize())), ProjectDto::of
         );
+    }
+
+    @Transactional
+    public void likeProject(Long projectId, Long userId) {
+        Project project = getProjectById(projectId);
+        User user = userService.getById(userId);
+
+        checkIfProjectAlreadyLiked(project, user);
+
+        projectLikeRepository.save(
+                ProjectLike.builder()
+                        .project(project)
+                        .user(user)
+                        .build()
+        );
+    }
+
+    private void checkIfProjectAlreadyLiked(Project project, User user) {
+        projectLikeRepository.findByProjectAndUser(project, user)
+                .ifPresent(projectLike -> {
+                    throw new IllegalArgumentException("이미 좋아요를 누른 프로젝트입니다.");
+                });
     }
 
     private Project getProjectById(Long projectId) {

--- a/src/main/java/kpl/fiml/project/application/ProjectService.java
+++ b/src/main/java/kpl/fiml/project/application/ProjectService.java
@@ -91,10 +91,9 @@ public class ProjectService {
     }
 
     private void checkIfProjectAlreadyLiked(Project project, User user) {
-        projectLikeRepository.findByProjectAndUser(project, user)
-                .ifPresent(projectLike -> {
-                    throw new IllegalArgumentException("이미 좋아요를 누른 프로젝트입니다.");
-                });
+        if (projectLikeRepository.existsByProjectAndUser(project, user)) {
+            throw new IllegalArgumentException("이미 좋아요를 누른 프로젝트입니다.");
+        }
     }
 
     @Transactional

--- a/src/main/java/kpl/fiml/project/domain/ProjectLike.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectLike.java
@@ -1,0 +1,33 @@
+package kpl.fiml.project.domain;
+
+import jakarta.persistence.*;
+import kpl.fiml.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "project_likes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public ProjectLike(Project project, User user) {
+        this.project = project;
+        this.user = user;
+    }
+}

--- a/src/main/java/kpl/fiml/project/domain/ProjectLike.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectLike.java
@@ -9,7 +9,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "project_likes")
+@Table(name = "project_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"project_id", "user_id"})
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectLike {
 

--- a/src/main/java/kpl/fiml/project/domain/ProjectLike.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectLike.java
@@ -21,11 +21,11 @@ public class ProjectLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "project_id")
     private Project project;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/kpl/fiml/project/domain/ProjectLikeRepository.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectLikeRepository.java
@@ -1,0 +1,12 @@
+package kpl.fiml.project.domain;
+
+import kpl.fiml.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> {
+    Optional<ProjectLike> findByProjectAndUser(Project project, User user);
+}

--- a/src/main/java/kpl/fiml/project/domain/ProjectLikeRepository.java
+++ b/src/main/java/kpl/fiml/project/domain/ProjectLikeRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> {
     Optional<ProjectLike> findByProjectAndUser(Project project, User user);
+
+    boolean existsByProjectAndUser(Project project, User user);
 }

--- a/src/main/java/kpl/fiml/project/presentation/ProjectController.java
+++ b/src/main/java/kpl/fiml/project/presentation/ProjectController.java
@@ -68,6 +68,13 @@ public class ProjectController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/projects/{projectId}/like")
+    public ResponseEntity<Void> likeProject(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal User user) {
+        this.projectService.likeProject(projectId, user.getId());
+
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/projects")
     public ResponseEntity<PageResponse<Project, ProjectDto>> findProjects(@ModelAttribute ProjectListFindRequest request) {
         PageResponse<Project, ProjectDto> projectsBySearchConditions = this.projectService.findProjectsBySearchConditions(request);

--- a/src/main/java/kpl/fiml/project/presentation/ProjectController.java
+++ b/src/main/java/kpl/fiml/project/presentation/ProjectController.java
@@ -75,6 +75,13 @@ public class ProjectController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/projects/{projectId}/unlike")
+    public ResponseEntity<Void> unlikeProject(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal User user) {
+        this.projectService.unlikeProject(projectId, user.getId());
+
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/projects")
     public ResponseEntity<PageResponse<Project, ProjectDto>> findProjects(@ModelAttribute ProjectListFindRequest request) {
         PageResponse<Project, ProjectDto> projectsBySearchConditions = this.projectService.findProjectsBySearchConditions(request);

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -76,4 +76,13 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
     }
 
+    @Transactional
+    public void follow(Long followingId, Long followerId) {
+        User following = userRepository.findByIdAndDeletedAtIsNull(followingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+        User follower = userRepository.findByIdAndDeletedAtIsNull(followerId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+
+        follower.addFollowing(following);
+    }
 }

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -70,7 +70,7 @@ public class UserService {
         return passwordEncoder.encode(rawPassword);
     }
 
-    private User getById(Long userId) {
+    public User getById(Long userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
     }

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -101,4 +101,22 @@ public class UserService {
                     throw new IllegalArgumentException("이미 팔로우한 사용자 입니다.");
                 });
     }
+
+    @Transactional
+    public void unfollow(Long followingId, Long followerId) {
+        User following = userRepository.findByIdAndDeletedAtIsNull(followingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+        User follower = userRepository.findByIdAndDeletedAtIsNull(followerId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+
+        Following findFollowing = getByFolloInfo(following, follower);
+
+        followingRepository.delete(findFollowing);
+
+    }
+
+    private Following getByFolloInfo(User following, User follower) {
+        return followingRepository.findByFollowingUserAndFollowerUser(following, follower)
+                .orElseThrow(() -> new IllegalArgumentException("팔로우하지 않은 사용자 입니다."));
+    }
 }

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -4,7 +4,6 @@ import kpl.fiml.global.jwt.JwtTokenProvider;
 import kpl.fiml.user.domain.User;
 import kpl.fiml.user.domain.UserRepository;
 import kpl.fiml.user.dto.*;
-import kpl.fiml.user.vo.EmailVo;
 import kpl.fiml.user.vo.PasswordVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,7 +43,7 @@ public class UserService {
     public UserUpdateResponse updateUser(Long userId, UserUpdateRequest request) {
         User user = getById(userId);
         String encryptPassword = request.getPassword();
-        if(!encryptPassword.isBlank()) {
+        if (!encryptPassword.isBlank()) {
             encryptPassword = validateAndEncryptPassword(request.getPassword());
         }
         user.updateUser(request.getName(), request.getBio(), request.getProfileImage(), request.getEmail(), encryptPassword, request.getContact());

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -80,10 +80,8 @@ public class UserService {
 
     @Transactional
     public void follow(Long followingId, Long followerId) {
-        User following = userRepository.findByIdAndDeletedAtIsNull(followingId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
-        User follower = userRepository.findByIdAndDeletedAtIsNull(followerId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+        User following = this.getById(followingId);
+        User follower = this.getById(followerId);
 
         checkIfAlreadyFollowing(following, follower);
 
@@ -104,10 +102,8 @@ public class UserService {
 
     @Transactional
     public void unfollow(Long followingId, Long followerId) {
-        User following = userRepository.findByIdAndDeletedAtIsNull(followingId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
-        User follower = userRepository.findByIdAndDeletedAtIsNull(followerId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+        User following = this.getById(followingId);
+        User follower = this.getById(followerId);
 
         Following findFollowing = getByFolloInfo(following, follower);
 

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -105,13 +105,13 @@ public class UserService {
         User following = this.getById(followingId);
         User follower = this.getById(followerId);
 
-        Following findFollowing = getByFolloInfo(following, follower);
+        Following findFollowing = getFollowingByFollowInfo(following, follower);
 
         followingRepository.delete(findFollowing);
 
     }
 
-    private Following getByFolloInfo(User following, User follower) {
+    private Following getFollowingByFollowInfo(User following, User follower) {
         return followingRepository.findByFollowingUserAndFollowerUser(following, follower)
                 .orElseThrow(() -> new IllegalArgumentException("팔로우하지 않은 사용자 입니다."));
     }

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -94,10 +94,9 @@ public class UserService {
     }
 
     private void checkIfAlreadyFollowing(User following, User follower) {
-        this.followingRepository.findByFollowingUserAndFollowerUser(following, follower)
-                .ifPresent(follow -> {
-                    throw new IllegalArgumentException("이미 팔로우한 사용자 입니다.");
-                });
+        if (followingRepository.existsByFollowingUserAndFollowerUser(following, follower)) {
+            throw new IllegalArgumentException("이미 팔로우한 사용자 입니다.");
+        }
     }
 
     @Transactional

--- a/src/main/java/kpl/fiml/user/domain/Following.java
+++ b/src/main/java/kpl/fiml/user/domain/Following.java
@@ -20,11 +20,11 @@ public class Following {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "follower_id")
     private User followerUser;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "following_id")
     private User followingUser;
 

--- a/src/main/java/kpl/fiml/user/domain/Following.java
+++ b/src/main/java/kpl/fiml/user/domain/Following.java
@@ -1,0 +1,40 @@
+package kpl.fiml.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "followings",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"follower_id", "following_id"})
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Following {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private User followerUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private User followingUser;
+
+    @Builder
+    public Following(User followerUser, User followingUser) {
+        this.followerUser = followerUser;
+        this.followingUser = followingUser;
+    }
+
+    public boolean isDuplicate(User user, User following) {
+        return this.followerUser.isSameUser(user) && this.followingUser.isSameUser(following);
+    }
+}

--- a/src/main/java/kpl/fiml/user/domain/Following.java
+++ b/src/main/java/kpl/fiml/user/domain/Following.java
@@ -33,8 +33,4 @@ public class Following {
         this.followerUser = followerUser;
         this.followingUser = followingUser;
     }
-
-    public boolean isDuplicate(User user, User following) {
-        return this.followerUser.isSameUser(user) && this.followingUser.isSameUser(following);
-    }
 }

--- a/src/main/java/kpl/fiml/user/domain/FollowingRepository.java
+++ b/src/main/java/kpl/fiml/user/domain/FollowingRepository.java
@@ -1,0 +1,11 @@
+package kpl.fiml.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FollowingRepository extends JpaRepository<Following, Long> {
+    Optional<Following> findByFollowingUserAndFollowerUser(User following, User follower);
+}

--- a/src/main/java/kpl/fiml/user/domain/FollowingRepository.java
+++ b/src/main/java/kpl/fiml/user/domain/FollowingRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Repository
 public interface FollowingRepository extends JpaRepository<Following, Long> {
     Optional<Following> findByFollowingUserAndFollowerUser(User following, User follower);
+
+    boolean existsByFollowingUserAndFollowerUser(User following, User follower);
 }

--- a/src/main/java/kpl/fiml/user/domain/User.java
+++ b/src/main/java/kpl/fiml/user/domain/User.java
@@ -72,6 +72,26 @@ public class User extends BaseEntity implements UserDetails {
         this.roles.add("ROLE_USER"); // 권한 처리 필요로 하지 않아서 생성 시 기본 ROLE_USER
     }
 
+    public void addFollowing(User followingUser) {
+        checkDuplicateFollowing(followingUser);
+
+        Following following = Following.builder()
+                .followerUser(this)
+                .followingUser(followingUser)
+                .build();
+        this.followingList.add(following);
+        followingUser.followerList.add(following);
+    }
+
+    private void checkDuplicateFollowing(User followingUser) {
+        this.followingList.stream()
+                .filter(follow -> follow.isDuplicate(this, followingUser))
+                .findFirst()
+                .ifPresent(follow -> {
+                    throw new IllegalArgumentException("이미 팔로우 중인 사용자입니다.");
+                });
+    }
+
     public void increaseCash(Long amount) {
         if (amount < 0) {
             throw new IllegalArgumentException("금액은 음수가 될 수 없습니다.");

--- a/src/main/java/kpl/fiml/user/domain/User.java
+++ b/src/main/java/kpl/fiml/user/domain/User.java
@@ -54,12 +54,6 @@ public class User extends BaseEntity implements UserDetails {
     @OneToMany(mappedBy = "user")
     private List<Notice> noticeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "followerUser", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<Following> followingList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "followingUser", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<Following> followerList = new ArrayList<>();
-
     @Builder
     public User(String name, String bio, String profileImage, String email, String encryptPassword, String contact) {
         this.name = name;
@@ -70,26 +64,6 @@ public class User extends BaseEntity implements UserDetails {
         this.contact = new ContactVo(contact).getContact();
         this.cash = 0L;
         this.roles.add("ROLE_USER"); // 권한 처리 필요로 하지 않아서 생성 시 기본 ROLE_USER
-    }
-
-    public void addFollowing(User followingUser) {
-        checkDuplicateFollowing(followingUser);
-
-        Following following = Following.builder()
-                .followerUser(this)
-                .followingUser(followingUser)
-                .build();
-        this.followingList.add(following);
-        followingUser.followerList.add(following);
-    }
-
-    private void checkDuplicateFollowing(User followingUser) {
-        this.followingList.stream()
-                .filter(follow -> follow.isDuplicate(this, followingUser))
-                .findFirst()
-                .ifPresent(follow -> {
-                    throw new IllegalArgumentException("이미 팔로우 중인 사용자입니다.");
-                });
     }
 
     public void increaseCash(Long amount) {

--- a/src/main/java/kpl/fiml/user/domain/User.java
+++ b/src/main/java/kpl/fiml/user/domain/User.java
@@ -5,7 +5,6 @@ import kpl.fiml.global.common.BaseEntity;
 import kpl.fiml.notice.domain.Notice;
 import kpl.fiml.user.vo.ContactVo;
 import kpl.fiml.user.vo.EmailVo;
-import kpl.fiml.user.vo.PasswordVo;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,6 +54,12 @@ public class User extends BaseEntity implements UserDetails {
 
     @OneToMany(mappedBy = "user")
     private List<Notice> noticeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "followerUser", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Following> followingList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "followingUser", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<Following> followerList = new ArrayList<>();
 
     @Builder
     public User(String name, String bio, String profileImage, String email, String encryptPassword, String contact) {

--- a/src/main/java/kpl/fiml/user/domain/User.java
+++ b/src/main/java/kpl/fiml/user/domain/User.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -26,7 +25,7 @@ public class User extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long id;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -115,11 +114,11 @@ public class User extends BaseEntity implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.roles.stream()
                 .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public boolean isSameUser(User user) {
-        return this.Id.equals(user.getId());
+        return this.id.equals(user.getId());
     }
 
     @Override

--- a/src/main/java/kpl/fiml/user/presentation/UserController.java
+++ b/src/main/java/kpl/fiml/user/presentation/UserController.java
@@ -1,10 +1,12 @@
 package kpl.fiml.user.presentation;
 
 import kpl.fiml.user.application.UserService;
+import kpl.fiml.user.domain.User;
 import kpl.fiml.user.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -47,6 +49,13 @@ public class UserController {
         UserDeleteResponse response = userService.deleteById(id);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping("/users/{followingId}/follow")
+    public ResponseEntity<Void> follow(@PathVariable("followingId") Long followingId, @AuthenticationPrincipal User user) {
+        this.userService.follow(followingId, user.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PostMapping("/users/test")

--- a/src/main/java/kpl/fiml/user/presentation/UserController.java
+++ b/src/main/java/kpl/fiml/user/presentation/UserController.java
@@ -58,6 +58,13 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @PostMapping("/users/{followingId}/unfollow")
+    public ResponseEntity<Void> unfollow(@PathVariable("followingId") Long followingId, @AuthenticationPrincipal User user) {
+        this.userService.unfollow(followingId, user.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
     @PostMapping("/users/test")
     public String test() {
         // security ROLE_USER 권한 확인용 api


### PR DESCRIPTION
- Unique 설정

팔로우와 좋아요는 데이터베이스에 하나의 쌍만 존재해야하는 것이 확정적이므로 unique 설정

- User - Following / Project - ProjectLike

Project 처럼 `OneToMany` 관계를 설정하여 추가 및 삭제하는 방향으로 구현하였다가,
팔로우나 찜하기는 많게는 1만개 이상이 연관 관계로 설정될 수 있기 때문에 Repository에서 직접 처리하는 방식으로 로직 구현하였습니다.

- 도메인 위치

Following은 User 하위 도메인이라 생각하여 User 내부에 생성하였고,
ProjectLike도 마찬가지로 Project 도메인 내부에 넣었습니다.

- 등록 및 해제

팔로우 등록/해제 프로젝트 좋아요/해제를 각각 하나의 API로 생성하였으며,
서비스 로직에서 조회하는 검증을 추가하여 (Unique 설정하였으나)Sql 에러가 발생하지 않도록 구현하였습니다.