### PR TITLE
51 로그아웃 구현 및 user controller 테스트코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,6 @@ src/main/resources/application.yaml
 
 # Querydsl
 src/main/generated
+
+# Test
+src/test/resources/application.yml

--- a/src/main/java/kpl/fiml/global/exception/ErrorResponse.java
+++ b/src/main/java/kpl/fiml/global/exception/ErrorResponse.java
@@ -1,0 +1,4 @@
+package kpl.fiml.global.exception;
+
+public record ErrorResponse(String errorCode, String message) {
+}

--- a/src/main/java/kpl/fiml/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/kpl/fiml/global/jwt/JwtTokenProvider.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class JwtTokenProvider {
 
     private final String secretKey;
-    private static final long TOKEN_VALID_TIME = 60 * 60 * 1000L;  // 토큰 유효시간 1시간
+    private static final long TOKEN_VALID_TIME = 30 * 60 * 1000L;  // 토큰 유효시간 30분
     private final UserDetailsService userDetailsService;
 
     public JwtTokenProvider(@Value("${JWT_KEY}") String secretKey, UserDetailsService userDetailsService) {

--- a/src/main/java/kpl/fiml/notice/domain/Notice.java
+++ b/src/main/java/kpl/fiml/notice/domain/Notice.java
@@ -42,11 +42,21 @@ public class Notice extends BaseEntity {
         this.project = project;
     }
 
-    public void updateContent(String content) {
+    public void updateContent(String content, User loginUser) {
+        validateLoginUser(loginUser);
+
         this.content = Objects.requireNonNull(content, "content 가 null 입니다");
     }
 
-    public void deleteNotice() {
+    public void deleteNotice(User loginUser) {
+        validateLoginUser(loginUser);
+
         delete();
+    }
+
+    private void validateLoginUser(User loginUser) {
+        if(!loginUser.isSameUser(this.user)) {
+            throw new IllegalArgumentException("Notice 접근 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/kpl/fiml/user/application/UserDetailServiceImpl.java
+++ b/src/main/java/kpl/fiml/user/application/UserDetailServiceImpl.java
@@ -2,6 +2,7 @@ package kpl.fiml.user.application;
 
 import kpl.fiml.user.domain.UserRepository;
 import kpl.fiml.user.exception.EmailNotFoundException;
+import kpl.fiml.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -20,6 +21,6 @@ public class UserDetailServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmailAndDeletedAtIsNull(email)
-                .orElseThrow(() -> new EmailNotFoundException("가입된 E-MAIL이 아닙니다.", "EMAIL_NOT_FOUND"));
+                .orElseThrow(() -> new EmailNotFoundException(UserErrorCode.EMAIL_NOT_FOUND));
     }
 }

--- a/src/main/java/kpl/fiml/user/application/UserDetailServiceImpl.java
+++ b/src/main/java/kpl/fiml/user/application/UserDetailServiceImpl.java
@@ -1,6 +1,7 @@
 package kpl.fiml.user.application;
 
 import kpl.fiml.user.domain.UserRepository;
+import kpl.fiml.user.exception.EmailNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -19,6 +20,6 @@ public class UserDetailServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmailAndDeletedAtIsNull(email)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EmailNotFoundException("가입된 E-MAIL이 아닙니다.", "EMAIL_NOT_FOUND"));
     }
 }

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -13,6 +13,7 @@ import kpl.fiml.user.dto.response.LoginResponse;
 import kpl.fiml.user.dto.response.UserCreateResponse;
 import kpl.fiml.user.dto.response.UserDeleteResponse;
 import kpl.fiml.user.dto.response.UserUpdateResponse;
+import kpl.fiml.user.exception.EmailNotFoundException;
 import kpl.fiml.user.vo.PasswordVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -45,7 +46,7 @@ public class UserService {
     @Transactional
     public LoginResponse signIn(LoginRequest request) {
         User user = userRepository.findByEmailAndDeletedAtIsNull(request.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("가입된 E-MAIL이 아닙니다."));
+                .orElseThrow(() -> new EmailNotFoundException("가입된 E-MAIL이 아닙니다.", "EMAIL_NOT_FOUND"));
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -59,15 +59,11 @@ public class UserService {
         User user = getById(id);
         User loginUser = getById(loginUserId);
 
-        if (!user.isSameUser(loginUser)) {
-            throw new IllegalArgumentException("사용자 수정 권한이 없습니다.");
-        }
-
         String encryptPassword = request.getPassword();
         if (!encryptPassword.isBlank()) {
             encryptPassword = validateAndEncryptPassword(request.getPassword());
         }
-        user.updateUser(request.getName(), request.getBio(), request.getProfileImage(), request.getEmail(), encryptPassword, request.getContact());
+        user.updateUser(loginUser, request.getName(), request.getBio(), request.getProfileImage(), request.getEmail(), encryptPassword, request.getContact());
 
         return UserUpdateResponse.of(user.getId(), user.getName(), user.getBio(), user.getProfileImage(), user.getEmail(), user.getPassword(), user.getContact());
     }
@@ -76,9 +72,7 @@ public class UserService {
         User findUser = getById(userId);
         User loginUser = getById(loginUserId);
 
-        if (!findUser.isSameUser(loginUser)) {
-            throw new IllegalArgumentException("마이페이지 접근 권한이 없습니다.");
-        }
+        validateUserAccess(loginUser, findUser);
 
         return UserDto.of(findUser.getId(), findUser.getName(), findUser.getBio(), findUser.getProfileImage(), findUser.getEmail(), findUser.getContact(), findUser.getCash(), findUser.getCreatedAt(), findUser.getUpdatedAt());
     }
@@ -88,22 +82,25 @@ public class UserService {
         User user = getById(userId);
         User loginUser = getById(loginUserId);
 
-        if (!user.isSameUser(loginUser)) {
-            throw new IllegalArgumentException("사용자 삭제 권한이 없습니다.");
-        }
-        user.deleteUser();
+        user.deleteUser(loginUser);
 
         return UserDeleteResponse.of(user.getId());
-    }
-
-    private String validateAndEncryptPassword(String password) {
-        String rawPassword = new PasswordVo(password).getPassword();
-        return passwordEncoder.encode(rawPassword);
     }
 
     public User getById(Long userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+    }
+
+    private void validateUserAccess(User loginUser, User targetUser) {
+        if(!targetUser.isSameUser(loginUser)) {
+            throw new IllegalArgumentException("User 정보 조회 권한이 없습니다.");
+        }
+    }
+
+    private String validateAndEncryptPassword(String password) {
+        String rawPassword = new PasswordVo(password).getPassword();
+        return passwordEncoder.encode(rawPassword);
     }
 
     @Transactional

--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -14,6 +14,7 @@ import kpl.fiml.user.dto.response.UserCreateResponse;
 import kpl.fiml.user.dto.response.UserDeleteResponse;
 import kpl.fiml.user.dto.response.UserUpdateResponse;
 import kpl.fiml.user.exception.EmailNotFoundException;
+import kpl.fiml.user.exception.UserErrorCode;
 import kpl.fiml.user.vo.PasswordVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -46,7 +47,7 @@ public class UserService {
     @Transactional
     public LoginResponse signIn(LoginRequest request) {
         User user = userRepository.findByEmailAndDeletedAtIsNull(request.getEmail())
-                .orElseThrow(() -> new EmailNotFoundException("가입된 E-MAIL이 아닙니다.", "EMAIL_NOT_FOUND"));
+                .orElseThrow(() -> new EmailNotFoundException(UserErrorCode.EMAIL_NOT_FOUND));
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }

--- a/src/main/java/kpl/fiml/user/domain/User.java
+++ b/src/main/java/kpl/fiml/user/domain/User.java
@@ -84,7 +84,9 @@ public class User extends BaseEntity implements UserDetails {
         this.cash -= amount;
     }
 
-    public void updateUser(String name, String bio, String profileImage, String email, String encryptPassword, String contact) {
+    public void updateUser(User loginUser, String name, String bio, String profileImage, String email, String encryptPassword, String contact) {
+        validateLoginUser(loginUser);
+
         if (!name.isBlank()) {
             this.name = name;
         }
@@ -101,8 +103,20 @@ public class User extends BaseEntity implements UserDetails {
         }
     }
 
-    public void deleteUser() {
+    public void deleteUser(User loginUser) {
+        validateLoginUser(loginUser);
+
         delete();
+    }
+
+    public boolean isSameUser(User user) {
+        return this.id.equals(user.getId());
+    }
+
+    private void validateLoginUser(User loginUser) {
+        if(!loginUser.isSameUser(this)) {
+            throw new IllegalArgumentException("User 접근 권한이 없습니다.");
+        }
     }
 
     @Override
@@ -110,10 +124,6 @@ public class User extends BaseEntity implements UserDetails {
         return this.roles.stream()
                 .map(SimpleGrantedAuthority::new)
                 .toList();
-    }
-
-    public boolean isSameUser(User user) {
-        return this.id.equals(user.getId());
     }
 
     @Override

--- a/src/main/java/kpl/fiml/user/dto/request/LoginRequest.java
+++ b/src/main/java/kpl/fiml/user/dto/request/LoginRequest.java
@@ -1,9 +1,11 @@
 package kpl.fiml.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class LoginRequest {
     @NotBlank(message = "이메일은 필수 입력값 입니다.")
     private String email;

--- a/src/main/java/kpl/fiml/user/dto/request/UserCreateRequest.java
+++ b/src/main/java/kpl/fiml/user/dto/request/UserCreateRequest.java
@@ -3,9 +3,11 @@ package kpl.fiml.user.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import kpl.fiml.user.domain.User;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class UserCreateRequest {
     @NotBlank(message = "이름은 필수 입력값 입니다.")
     private String name;

--- a/src/main/java/kpl/fiml/user/exception/EmailNotFoundException.java
+++ b/src/main/java/kpl/fiml/user/exception/EmailNotFoundException.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 public class EmailNotFoundException extends RuntimeException {
     private final String errorCode;
 
-    public EmailNotFoundException(String message, String errorCode) {
-        super(message);
-        this.errorCode = errorCode;
+    public EmailNotFoundException(UserErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.getCode();
     }
 }

--- a/src/main/java/kpl/fiml/user/exception/EmailNotFoundException.java
+++ b/src/main/java/kpl/fiml/user/exception/EmailNotFoundException.java
@@ -1,0 +1,13 @@
+package kpl.fiml.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EmailNotFoundException extends RuntimeException {
+    private final String errorCode;
+
+    public EmailNotFoundException(String message, String errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kpl/fiml/user/exception/InvalidEmailException.java
+++ b/src/main/java/kpl/fiml/user/exception/InvalidEmailException.java
@@ -1,0 +1,12 @@
+package kpl.fiml.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidEmailException extends RuntimeException {
+    private final String errorCode;
+    public InvalidEmailException(String message, String errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kpl/fiml/user/exception/InvalidEmailException.java
+++ b/src/main/java/kpl/fiml/user/exception/InvalidEmailException.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 @Getter
 public class InvalidEmailException extends RuntimeException {
     private final String errorCode;
-    public InvalidEmailException(String message, String errorCode) {
-        super(message);
-        this.errorCode = errorCode;
+    public InvalidEmailException(UserErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.getCode();
     }
 }

--- a/src/main/java/kpl/fiml/user/exception/InvalidPasswordException.java
+++ b/src/main/java/kpl/fiml/user/exception/InvalidPasswordException.java
@@ -1,0 +1,12 @@
+package kpl.fiml.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidPasswordException extends RuntimeException {
+    private final String errorCode;
+    public InvalidPasswordException(String message, String errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kpl/fiml/user/exception/InvalidPasswordException.java
+++ b/src/main/java/kpl/fiml/user/exception/InvalidPasswordException.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 @Getter
 public class InvalidPasswordException extends RuntimeException {
     private final String errorCode;
-    public InvalidPasswordException(String message, String errorCode) {
-        super(message);
-        this.errorCode = errorCode;
+    public InvalidPasswordException(UserErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.getCode();
     }
 }

--- a/src/main/java/kpl/fiml/user/exception/UserErrorCode.java
+++ b/src/main/java/kpl/fiml/user/exception/UserErrorCode.java
@@ -1,0 +1,17 @@
+package kpl.fiml.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode {
+
+    INVALID_EMAIL("유효하지 않은 이메일 주소입니다.", "INVALID_EMAIL"),
+    INVALID_PASSWORD("비밀번호는 8자 이상, 특수문자 1가지를 꼭 포함해야 합니다.", "INVALID_PASSWORD"),
+    EMAIL_NOT_FOUND("가입된 E-MAIL이 아닙니다.", "EMAIL_NOT_FOUND");
+
+    private final String message;
+    private final String code;
+
+}

--- a/src/main/java/kpl/fiml/user/exception/UserGlobalExceptionHandler.java
+++ b/src/main/java/kpl/fiml/user/exception/UserGlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package kpl.fiml.user.exception;
+
+import kpl.fiml.global.exception.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class UserGlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidEmailException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleInvalidEmailException(InvalidEmailException e) {
+        ErrorResponse response = new ErrorResponse(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(InvalidPasswordException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleInvalidPasswordException(InvalidPasswordException e) {
+        ErrorResponse response = new ErrorResponse(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(EmailNotFoundException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity<ErrorResponse> handleEmailNotFoundException(EmailNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+}

--- a/src/main/java/kpl/fiml/user/presentation/UserController.java
+++ b/src/main/java/kpl/fiml/user/presentation/UserController.java
@@ -3,7 +3,7 @@ package kpl.fiml.user.presentation;
 import jakarta.validation.Valid;
 import kpl.fiml.user.application.UserService;
 import kpl.fiml.user.domain.User;
-import kpl.fiml.user.dto.*;
+import kpl.fiml.user.dto.UserDto;
 import kpl.fiml.user.dto.request.LoginRequest;
 import kpl.fiml.user.dto.request.UserCreateRequest;
 import kpl.fiml.user.dto.request.UserUpdateRequest;

--- a/src/main/java/kpl/fiml/user/vo/EmailVo.java
+++ b/src/main/java/kpl/fiml/user/vo/EmailVo.java
@@ -1,6 +1,7 @@
 package kpl.fiml.user.vo;
 
 import kpl.fiml.user.exception.InvalidEmailException;
+import kpl.fiml.user.exception.UserErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -13,7 +14,7 @@ public class EmailVo {
 
     public EmailVo(String email) {
         if (!isValidEmail(email)) {
-            throw new InvalidEmailException("유효하지 않은 이메일 주소입니다.", "INVALID_EMAIL");
+            throw new InvalidEmailException(UserErrorCode.INVALID_EMAIL);
         }
         this.email = email;
     }

--- a/src/main/java/kpl/fiml/user/vo/EmailVo.java
+++ b/src/main/java/kpl/fiml/user/vo/EmailVo.java
@@ -1,7 +1,9 @@
 package kpl.fiml.user.vo;
 
+import kpl.fiml.user.exception.InvalidEmailException;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class EmailVo {
@@ -11,7 +13,7 @@ public class EmailVo {
 
     public EmailVo(String email) {
         if (!isValidEmail(email)) {
-            throw new IllegalArgumentException("유효하지 않은 이메일 주소입니다.");
+            throw new InvalidEmailException("유효하지 않은 이메일 주소입니다.", "INVALID_EMAIL");
         }
         this.email = email;
     }

--- a/src/main/java/kpl/fiml/user/vo/PasswordVo.java
+++ b/src/main/java/kpl/fiml/user/vo/PasswordVo.java
@@ -1,6 +1,7 @@
 package kpl.fiml.user.vo;
 
 import kpl.fiml.user.exception.InvalidPasswordException;
+import kpl.fiml.user.exception.UserErrorCode;
 import lombok.Getter;
 
 @Getter
@@ -12,7 +13,7 @@ public class PasswordVo {
 
     public PasswordVo(String password) {
         if (!isValidPassword(password)) {
-            throw new InvalidPasswordException("비밀번호는 8자 이상, 특수문자 1가지를 꼭 포함해야 합니다.", "INVALID_PASSWORD");
+            throw new InvalidPasswordException(UserErrorCode.INVALID_PASSWORD);
         }
         this.password = password;
     }

--- a/src/main/java/kpl/fiml/user/vo/PasswordVo.java
+++ b/src/main/java/kpl/fiml/user/vo/PasswordVo.java
@@ -1,5 +1,6 @@
 package kpl.fiml.user.vo;
 
+import kpl.fiml.user.exception.InvalidPasswordException;
 import lombok.Getter;
 
 @Getter
@@ -11,7 +12,7 @@ public class PasswordVo {
 
     public PasswordVo(String password) {
         if (!isValidPassword(password)) {
-            throw new IllegalArgumentException("비밀번호는 8자 이상, 특수문자 1가지를 꼭 포함해야 합니다.");
+            throw new InvalidPasswordException("비밀번호는 8자 이상, 특수문자 1가지를 꼭 포함해야 합니다.", "INVALID_PASSWORD");
         }
         this.password = password;
     }

--- a/src/test/java/kpl/fiml/user/application/UserServiceTest.java
+++ b/src/test/java/kpl/fiml/user/application/UserServiceTest.java
@@ -1,0 +1,72 @@
+package kpl.fiml.user.application;
+
+import kpl.fiml.global.jwt.JwtTokenProvider;
+import kpl.fiml.user.domain.UserRepository;
+import kpl.fiml.user.dto.request.UserCreateRequest;
+import kpl.fiml.user.dto.response.UserCreateResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("user 생성에 성공합니다.")
+    public void testCreateUser_success() {
+        UserCreateRequest request = UserCreateRequest.builder()
+                .bio("")
+                .contact("01012345678")
+                .email("test@example.com")
+                .name("Test Name")
+                .password("password123!")
+                .profileImage("")
+                .build();
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull("test@example.com")).thenReturn(false);
+
+        String dummyEncryptedPassword = "dummyEncryptedPassword";
+        when(userRepository.save(any())).thenReturn(request.toEntity(dummyEncryptedPassword));
+
+        UserCreateResponse response = userService.createUser(request);
+
+        assertNotNull(response);
+        verify(userRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("사용자 생성에 실패합니다.")
+    public void testCreateUser_DuplicateEmail() {
+        UserCreateRequest request = UserCreateRequest.builder()
+                .bio("")
+                .contact("01012345678")
+                .email("test@example.com")
+                .name("Test Name")
+                .password("password123!")
+                .profileImage("")
+                .build();
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull("test@example.com")).thenReturn(true);
+        assertThrows(IllegalArgumentException.class, () -> userService.createUser(request));
+    }
+}

--- a/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
+++ b/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
@@ -1,0 +1,77 @@
+package kpl.fiml.user.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kpl.fiml.user.domain.UserRepository;
+import kpl.fiml.user.dto.request.UserCreateRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserController userController;
+
+    @BeforeEach
+    void init() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void testCreateUser_Success() throws Exception {
+        UserCreateRequest request = UserCreateRequest.builder()
+                .bio("")
+                .contact("01012345678")
+                .email("test1@example.com")
+                .name("Test Name")
+                .password("password123!")
+                .profileImage("")
+                .build();
+
+        mockMvc.perform(post("/api/v1/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isCreated()) // 201 Created 상태 확인
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.userId").isNumber()) // 응답의 userId가 숫자인지 확인
+                .andExpect(jsonPath("$.userId").isNotEmpty()); // 응답의 userId가 비어있지 않은지 확인
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: 유효하지 않은 이메일 주소")
+    public void testCreateUser_Fail_InvalidEmail() throws Exception {
+        // Given
+        UserCreateRequest request = UserCreateRequest.builder()
+                .bio("")
+                .contact("01012345678")
+                .email("invalid-email")
+                .name("Test Name")
+                .password("password123!")
+                .profileImage("")
+                .build();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                userController.createUser(request)
+        );
+
+    }
+
+}

--- a/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
+++ b/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
@@ -3,15 +3,17 @@ package kpl.fiml.user.presentation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kpl.fiml.user.domain.UserRepository;
 import kpl.fiml.user.dto.request.UserCreateRequest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -37,6 +39,7 @@ public class UserControllerTest {
     @Test
     @DisplayName("회원가입 성공")
     public void testCreateUser_Success() throws Exception {
+        // Given
         UserCreateRequest request = UserCreateRequest.builder()
                 .bio("")
                 .contact("01012345678")
@@ -46,6 +49,7 @@ public class UserControllerTest {
                 .profileImage("")
                 .build();
 
+        // When Then
         mockMvc.perform(post("/api/v1/users/join")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
@@ -68,10 +72,13 @@ public class UserControllerTest {
                 .profileImage("")
                 .build();
 
-        Assertions.assertThrows(IllegalArgumentException.class, () ->
-                userController.createUser(request)
-        );
-
+        // When Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_EMAIL"))
+                .andExpect(jsonPath("$.message").value("유효하지 않은 이메일 주소입니다."));
     }
 
 }

--- a/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
+++ b/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
@@ -2,6 +2,7 @@ package kpl.fiml.user.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kpl.fiml.user.domain.UserRepository;
+import kpl.fiml.user.dto.request.LoginRequest;
 import kpl.fiml.user.dto.request.UserCreateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,14 +28,6 @@ public class UserControllerTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private UserController userController;
-
-    @BeforeEach
-    void init() {
-        userRepository.deleteAll();
-    }
 
     @Test
     @DisplayName("회원가입 성공")
@@ -103,4 +96,22 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상, 특수문자 1가지를 꼭 포함해야 합니다."));
     }
 
+    @Test
+    @DisplayName("로그인 성공")
+    void testLogin_Success() throws Exception {
+        // Given
+        LoginRequest request = LoginRequest.builder()
+                .email("test1@example.com")
+                .password("password123!")
+                .build();
+
+        // When Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.jwtToken").isString())
+                .andExpect(jsonPath("$.username").isString())
+                .andExpect(jsonPath("$.email").isString());
+    }
 }

--- a/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
+++ b/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
@@ -81,4 +81,26 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("유효하지 않은 이메일 주소입니다."));
     }
 
+    @Test
+    @DisplayName("회원가입 실패: 유효하지 않은 비밀번호")
+    public void testCreateUser_Fail_InvalidPassword() throws Exception {
+        // Given
+        UserCreateRequest request = UserCreateRequest.builder()
+                .bio("")
+                .contact("01012345678")
+                .email("test@example.com")
+                .name("Test Name")
+                .password("invalidpassword")  // 유효하지 않은 비밀번호
+                .profileImage("")
+                .build();
+
+        // When Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_PASSWORD"))
+                .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상, 특수문자 1가지를 꼭 포함해야 합니다."));
+    }
+
 }

--- a/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
+++ b/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
@@ -29,11 +29,8 @@ public class UserControllerTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Test
-    @DisplayName("회원가입 성공")
-    public void testCreateUser_Success() throws Exception {
-        // Given
-        UserCreateRequest request = UserCreateRequest.builder()
+    private UserCreateRequest create_user() {
+        return UserCreateRequest.builder()
                 .bio("")
                 .contact("01012345678")
                 .email("test1@example.com")
@@ -41,6 +38,13 @@ public class UserControllerTest {
                 .password("password123!")
                 .profileImage("")
                 .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void testCreateUser_Success() throws Exception {
+        // Given
+        UserCreateRequest request = create_user();
 
         // When Then
         mockMvc.perform(post("/api/v1/users/join")

--- a/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
+++ b/src/test/java/kpl/fiml/user/presentation/UserControllerTest.java
@@ -114,4 +114,22 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.username").isString())
                 .andExpect(jsonPath("$.email").isString());
     }
+
+    @Test
+    @DisplayName("로그인 실패: 존재하지 않는 이메일")
+    void testLogin_Fail_EmailNotFound() throws Exception {
+        // Given
+        LoginRequest request = LoginRequest.builder()
+                .email("nonexistent@example.com")
+                .password("password123!")
+                .build();
+
+        // When Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("EMAIL_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("가입된 E-MAIL이 아닙니다."));
+    }
 }


### PR DESCRIPTION
### Logout 구현
- 토큰 유효 시간을 줄이고, refresh token이 없기 때문에 따로 구현하지 않는 방향으로 선택했습니다.

---

### Validation 추가
- validation 추가 : entity 내부에 함수가 존재하는 update, delete에 대해서는 validate 코드를 entity 내부로 옮겼습니다.
- 바로 repository로 접근하는 메서드에 대한 validation은 service 계층에서 진행하였습니다.

---

### Test 코드 추가
- user service 계층 unit test 코드 테스트겸 두가지만 일단 작성해두었습니다.
- user controller 통합 테스트 작성하였습니다 (pr이 두꺼워진다고 생각해서 일단 모두 작성하지 않고 pr 작성합니다!)
   - 실패 테스트 코드 작성시에 custom exception 이 필요해서 임의로 global/exception 디렉토리에 [ErrorResponse](src/main/java/kpl/fiml/global/exception/ErrorResponse.java) record 형식으로 생성 후에 user/exception 내부에 user custom exception 생성하였습니다.