### PR TITLE
55 후원 테스트코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/kpl/fiml/project/exception/RewardErrorCode.java
+++ b/src/main/java/kpl/fiml/project/exception/RewardErrorCode.java
@@ -1,0 +1,13 @@
+package kpl.fiml.project.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RewardErrorCode {
+
+    REWARD_NOT_FOUND("리워드 정보가 존재하지 않습니다.");
+
+    private final String message;
+}

--- a/src/main/java/kpl/fiml/project/exception/RewardGlobalExceptionHandler.java
+++ b/src/main/java/kpl/fiml/project/exception/RewardGlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package kpl.fiml.project.exception;
+
+import kpl.fiml.global.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class RewardGlobalExceptionHandler {
+
+    @ExceptionHandler(RewardNotFoundException.class)
+    public ResponseEntity<ErrorResponse> catchRewardNotFoundException(RewardNotFoundException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+}

--- a/src/main/java/kpl/fiml/project/exception/RewardNotFoundException.java
+++ b/src/main/java/kpl/fiml/project/exception/RewardNotFoundException.java
@@ -1,0 +1,14 @@
+package kpl.fiml.project.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RewardNotFoundException extends RuntimeException {
+
+    private final String errorCode;
+
+    public RewardNotFoundException(RewardErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
+++ b/src/main/java/kpl/fiml/sponsor/application/SponsorService.java
@@ -6,6 +6,8 @@ import kpl.fiml.project.application.ProjectService;
 import kpl.fiml.project.domain.Project;
 import kpl.fiml.project.domain.Reward;
 import kpl.fiml.project.domain.RewardRepository;
+import kpl.fiml.project.exception.RewardErrorCode;
+import kpl.fiml.project.exception.RewardNotFoundException;
 import kpl.fiml.sponsor.domain.Sponsor;
 import kpl.fiml.sponsor.domain.SponsorRepository;
 import kpl.fiml.sponsor.dto.request.SponsorCreateRequest;
@@ -139,6 +141,6 @@ public class SponsorService {
 
     private Reward getRewardById(Long rewardId) {
         return rewardRepository.findByIdAndDeletedAtIsNull(rewardId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 리워드가 존재하지 않습니다."));
+                .orElseThrow(() -> new RewardNotFoundException(RewardErrorCode.REWARD_NOT_FOUND));
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
+++ b/src/main/java/kpl/fiml/sponsor/domain/Sponsor.java
@@ -3,6 +3,8 @@ package kpl.fiml.sponsor.domain;
 import jakarta.persistence.*;
 import kpl.fiml.global.common.BaseEntity;
 import kpl.fiml.project.domain.Reward;
+import kpl.fiml.sponsor.exception.InvalidTotalAmountException;
+import kpl.fiml.sponsor.exception.SponsorErrorCode;
 import kpl.fiml.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -75,7 +77,7 @@ public class Sponsor extends BaseEntity {
 
     private void validateTotalAmount(Reward reward, Long totalAmount) {
         if (reward.checkUnderflowPrice(totalAmount)) {
-            throw new IllegalArgumentException("후원 금액이 리워드 가격보다 적습니다.");
+            throw new InvalidTotalAmountException(SponsorErrorCode.INVALID_TOTAL_AMOUNT);
         }
     }
 }

--- a/src/main/java/kpl/fiml/sponsor/dto/request/SponsorCreateRequest.java
+++ b/src/main/java/kpl/fiml/sponsor/dto/request/SponsorCreateRequest.java
@@ -1,6 +1,6 @@
 package kpl.fiml.sponsor.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import kpl.fiml.project.domain.Reward;
 import kpl.fiml.sponsor.domain.Sponsor;
 import kpl.fiml.user.domain.User;
@@ -9,10 +9,10 @@ import lombok.Getter;
 @Getter
 public class SponsorCreateRequest {
 
-    @NotBlank
+    @NotNull
     private Long rewardId;
 
-    @NotBlank
+    @NotNull
     private Long totalAmount;
 
     public Sponsor toEntity(User user, Reward reward) {

--- a/src/main/java/kpl/fiml/sponsor/dto/request/SponsorUpdateRequest.java
+++ b/src/main/java/kpl/fiml/sponsor/dto/request/SponsorUpdateRequest.java
@@ -1,6 +1,6 @@
 package kpl.fiml.sponsor.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import kpl.fiml.project.domain.Reward;
 import kpl.fiml.sponsor.domain.Sponsor;
 import kpl.fiml.user.domain.User;
@@ -9,10 +9,10 @@ import lombok.Getter;
 @Getter
 public class SponsorUpdateRequest {
 
-    @NotBlank
+    @NotNull
     private Long rewardId;
 
-    @NotBlank
+    @NotNull
     private Long totalAmount;
 
     public Sponsor toEntity(User user, Reward reward) {

--- a/src/main/java/kpl/fiml/sponsor/exception/InvalidTotalAmountException.java
+++ b/src/main/java/kpl/fiml/sponsor/exception/InvalidTotalAmountException.java
@@ -1,0 +1,14 @@
+package kpl.fiml.sponsor.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidTotalAmountException extends RuntimeException {
+
+    private final String errorCode;
+
+    public InvalidTotalAmountException(SponsorErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/exception/SponsorAccessDeniedException.java
+++ b/src/main/java/kpl/fiml/sponsor/exception/SponsorAccessDeniedException.java
@@ -1,0 +1,14 @@
+package kpl.fiml.sponsor.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SponsorAccessDeniedException extends RuntimeException {
+
+    private final String errorCode;
+
+    public SponsorAccessDeniedException(SponsorErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/exception/SponsorErrorCode.java
+++ b/src/main/java/kpl/fiml/sponsor/exception/SponsorErrorCode.java
@@ -1,0 +1,16 @@
+package kpl.fiml.sponsor.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SponsorErrorCode {
+
+    SPONSOR_NOT_FOUND("후원 정보가 존재하지 않습니다."),
+    INVALID_TOTAL_AMOUNT("후원 금액이 리워드 가격보다 적습니다."),
+    SPONSOR_ACCESS_DENIED("접근 가능한 후원 정보가 아닙니다."),
+    SPONSOR_MODIFY_DENIED("펀딩 종료 후에는 후원 수정 및 삭제가 불가합니다.");
+
+    private final String message;
+}

--- a/src/main/java/kpl/fiml/sponsor/exception/SponsorGlobalExceptionHandler.java
+++ b/src/main/java/kpl/fiml/sponsor/exception/SponsorGlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package kpl.fiml.sponsor.exception;
+
+import kpl.fiml.global.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class SponsorGlobalExceptionHandler {
+
+    @ExceptionHandler(SponsorNotFoundException.class)
+    public ResponseEntity<ErrorResponse> catchSponsorNotFoundException(SponsorNotFoundException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidTotalAmountException.class)
+    public ResponseEntity<ErrorResponse> catchInvalidTotalAmountException(InvalidTotalAmountException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(SponsorAccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> catchSponsorAccessDeniedException(SponsorAccessDeniedException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(SponsorModifyDeniedException.class)
+    public ResponseEntity<ErrorResponse> catchSponsorModifyDeniedException(SponsorModifyDeniedException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/exception/SponsorModifyDeniedException.java
+++ b/src/main/java/kpl/fiml/sponsor/exception/SponsorModifyDeniedException.java
@@ -1,0 +1,14 @@
+package kpl.fiml.sponsor.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SponsorModifyDeniedException extends RuntimeException {
+
+    private final String errorCode;
+
+    public SponsorModifyDeniedException(SponsorErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/kpl/fiml/sponsor/exception/SponsorNotFoundException.java
+++ b/src/main/java/kpl/fiml/sponsor/exception/SponsorNotFoundException.java
@@ -1,0 +1,14 @@
+package kpl.fiml.sponsor.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SponsorNotFoundException extends RuntimeException {
+
+    private final String errorCode;
+
+    public SponsorNotFoundException(SponsorErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/test/java/kpl/fiml/customMockUser/WithCustomMockUser.java
+++ b/src/test/java/kpl/fiml/customMockUser/WithCustomMockUser.java
@@ -1,0 +1,13 @@
+package kpl.fiml.customMockUser;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+    String email() default "aaa@gmail.com";
+    String contact() default "01012345678";
+}

--- a/src/test/java/kpl/fiml/customMockUser/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/kpl/fiml/customMockUser/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,39 @@
+package kpl.fiml.customMockUser;
+
+import kpl.fiml.user.domain.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        Long id = 1L;
+        String email = annotation.email();
+        String contact = annotation.contact();
+
+        User user = User.builder()
+                .email(email)
+                .contact(contact)
+                .build();
+        try {
+            Field userId = user.getClass().getDeclaredField("id");
+            userId.setAccessible(true);
+            userId.set(user, id);
+        } catch (NoSuchFieldException | IllegalAccessException ignored) {
+
+        }
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(user, "password", List.of(new SimpleGrantedAuthority("USER")));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+
+        return context;
+    }
+}

--- a/src/test/java/kpl/fiml/sponsor/application/SponsorServiceTest.java
+++ b/src/test/java/kpl/fiml/sponsor/application/SponsorServiceTest.java
@@ -1,0 +1,249 @@
+package kpl.fiml.sponsor.application;
+
+import kpl.fiml.payment.application.PaymentService;
+import kpl.fiml.project.application.ProjectService;
+import kpl.fiml.project.domain.Project;
+import kpl.fiml.project.domain.Reward;
+import kpl.fiml.project.domain.RewardRepository;
+import kpl.fiml.project.domain.enums.ProjectCategory;
+import kpl.fiml.sponsor.domain.Sponsor;
+import kpl.fiml.sponsor.domain.SponsorRepository;
+import kpl.fiml.sponsor.dto.request.SponsorCreateRequest;
+import kpl.fiml.sponsor.dto.request.SponsorUpdateRequest;
+import kpl.fiml.sponsor.dto.response.SponsorCreateResponse;
+import kpl.fiml.sponsor.dto.response.SponsorDeleteResponse;
+import kpl.fiml.sponsor.dto.response.SponsorDto;
+import kpl.fiml.user.application.UserService;
+import kpl.fiml.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class SponsorServiceTest {
+
+    @Mock
+    private SponsorRepository sponsorRepository;
+
+    @Mock
+    private RewardRepository rewardRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ProjectService projectService;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @InjectMocks
+    private SponsorService sponsorService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user = User.builder()
+                .email("abc@gmail.com")
+                .contact("01012345678")
+                .build();
+        Field userId = user.getClass().getDeclaredField("id");
+        userId.setAccessible(true);
+        userId.set(user, 1L);
+    }
+
+    @Test
+    @DisplayName("Sponsor를 생성할 수 있다.")
+    void testCreateSponsor() throws Exception {
+        // given
+        SponsorCreateRequest request = new SponsorCreateRequest();
+        Field rewardId = request.getClass().getDeclaredField("rewardId");
+        rewardId.setAccessible(true);
+        rewardId.set(request, 1L);
+        Field totalAmount = request.getClass().getDeclaredField("totalAmount");
+        totalAmount.setAccessible(true);
+        totalAmount.set(request, 60000L);
+
+        when(userService.getById(any())).thenReturn(user);
+
+        Project project = createProject(user);
+        Reward reward = createReward(50000L, project);
+        when(rewardRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(reward));
+
+        when(sponsorRepository.save(any())).thenReturn(request.toEntity(user, reward));
+
+        // when
+        SponsorCreateResponse response = sponsorService.createSponsor(request, user.getId());
+
+        // then
+        assertThat(response).isNotNull();
+        verify(sponsorRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("특정 회원의 후원 리스트를 조회할 수 있다.")
+    void testGetSponsorsByUser() throws Exception {
+        // given
+        when(userService.getById(any())).thenReturn(user);
+
+        Project project = createProject(user);
+        Reward reward1 = createReward(50000L, project);
+        Reward reward2 = createReward(123456L, project);
+
+        Sponsor sponsor1 = createSponsor(reward1, 50000L);
+        Sponsor sponsor2 = createSponsor(reward2, 987654L);
+        when(sponsorRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(sponsor1, sponsor2));
+
+        // when
+        List<SponsorDto> dtos = sponsorService.getSponsorsByUser(user.getId());
+
+        // then
+        assertThat(dtos).hasSize(2)
+                .extracting(SponsorDto::getTotalAmount)
+                .contains(sponsor1.getTotalAmount(), sponsor2.getTotalAmount());
+    }
+
+    @Test
+    @DisplayName("특정 프로젝트에 대한 후원 리스트를 조회할 수 있다.")
+    void testGetSponsorsByProject() throws Exception {
+        // given
+        when(userService.getById(any())).thenReturn(user);
+
+        Project project = createProject(user);
+        when(projectService.getProjectByIdWithUser(any())).thenReturn(project);
+
+        Reward reward1 = createReward(50000L, project);
+        Reward reward2 = createReward(123456L, project);
+        when(rewardRepository.findAllByProjectAndDeletedAtIsNull(project)).thenReturn(List.of(reward1, reward2));
+
+        Sponsor sponsor1 = createSponsor(reward1, 50000L);
+        Sponsor sponsor2 = createSponsor(reward2, 987654L);
+        Sponsor sponsor3 = createSponsor(reward2, 123499L);
+        when(sponsorRepository.findAllByReward(reward1)).thenReturn(List.of(sponsor1));
+        when(sponsorRepository.findAllByReward(reward2)).thenReturn(List.of(sponsor2, sponsor3));
+
+        // when
+        List<SponsorDto> dtos = sponsorService.getSponsorsByProject(1L, user.getId());
+
+        // then
+        assertThat(dtos).hasSize(3)
+                .extracting(SponsorDto::getTotalAmount)
+                .contains(sponsor1.getTotalAmount(), sponsor2.getTotalAmount(), sponsor3.getTotalAmount());
+    }
+
+    @Test
+    @DisplayName("후원자가 후원 정보를 수정할 수 있다.")
+    void testUpdateSponsor() throws Exception {
+        // given
+        SponsorUpdateRequest request = new SponsorUpdateRequest();
+        Field rewardId = request.getClass().getDeclaredField("rewardId");
+        rewardId.setAccessible(true);
+        rewardId.set(request, 1L);
+        Field totalAmount = request.getClass().getDeclaredField("totalAmount");
+        totalAmount.setAccessible(true);
+        totalAmount.set(request, 60000L);
+
+        when(userService.getById(any())).thenReturn(user);
+
+        Project project = createProject(user);
+        Reward reward = createReward(50000L, project);
+        when(rewardRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(reward));
+
+        Sponsor sponsor = createSponsor(reward, 50000L);
+        when(sponsorRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(sponsor));
+
+        // when
+        SponsorDto dto = sponsorService.updateSponsor(1L, request, user.getId());
+
+        // then
+        assertThat(dto.getTotalAmount()).isEqualTo(60000L);
+    }
+
+    @Test
+    @DisplayName("후원자가 후원을 취소할 수 있다.")
+    void testDeleteSponsorByUser() throws Exception {
+        // given
+        when(userService.getById(any())).thenReturn(user);
+
+        Project project = createProject(user);
+        Reward reward = createReward(50000L, project);
+        Sponsor sponsor = createSponsor(reward, 50000L);
+        when(sponsorRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(sponsor));
+
+        // when
+        SponsorDeleteResponse response = sponsorService.deleteSponsorByUser(1L, user.getId());
+
+        // then
+        assertThat(response.getDeleteAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("특정 프로젝트에 대한 전체 후원을 취소할 수 있다.")
+    void testDeleteSponsorsByProject() throws Exception {
+        // given
+        Project project = createProject(user);
+        Reward reward1 = createReward(50000L, project);
+        Reward reward2 = createReward(123456L, project);
+        when(rewardRepository.findAllByProjectAndDeletedAtIsNull(project)).thenReturn(List.of(reward1, reward2));
+
+        Sponsor sponsor1 = createSponsor(reward1, 50000L);
+        Sponsor sponsor2 = createSponsor(reward2, 987654L);
+        Sponsor sponsor3 = createSponsor(reward2, 123499L);
+        when(sponsorRepository.findAllByReward(reward1)).thenReturn(List.of(sponsor1));
+        when(sponsorRepository.findAllByReward(reward2)).thenReturn(List.of(sponsor2, sponsor3));
+
+        // when
+        sponsorService.deleteSponsorsByProject(project);
+
+        // then
+        assertThat(sponsor1.getDeletedAt()).isNotNull();
+        assertThat(sponsor2.getDeletedAt()).isNotNull();
+        assertThat(sponsor3.getDeletedAt()).isNotNull();
+    }
+
+    Project createProject(User user) throws Exception {
+        Project project = Project.builder()
+                .summary("summary")
+                .category(ProjectCategory.ART)
+                .user(user)
+                .build();
+        Field endAt = project.getClass().getDeclaredField("endAt");
+        endAt.setAccessible(true);
+        endAt.set(project, LocalDateTime.now().plusDays(1L));
+
+        return project;
+    }
+
+    Reward createReward(Long price, Project project) {
+        Reward reward = Reward.builder()
+                .quantityLimited(false)
+                .maxPurchaseQuantity(100000)
+                .price(price)
+                .build();
+        reward.setProject(project);
+
+        return reward;
+    }
+
+    Sponsor createSponsor(Reward reward, Long totalAmount) {
+        return Sponsor.builder()
+                .user(user)
+                .reward(reward)
+                .totalAmount(totalAmount)
+                .build();
+    }
+}

--- a/src/test/java/kpl/fiml/sponsor/domain/SponsorTest.java
+++ b/src/test/java/kpl/fiml/sponsor/domain/SponsorTest.java
@@ -1,6 +1,7 @@
 package kpl.fiml.sponsor.domain;
 
 import kpl.fiml.project.domain.Reward;
+import kpl.fiml.sponsor.exception.InvalidTotalAmountException;
 import kpl.fiml.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ public class SponsorTest {
 
         // when-then
         assertThatThrownBy(() -> Sponsor.builder().user(user).reward(reward).totalAmount(totalAmount).build())
-                .isInstanceOf(IllegalArgumentException.class) // TODO 커스텀 예외 생성 시 변경 필요
+                .isInstanceOf(InvalidTotalAmountException.class)
                 .hasMessageContaining("후원 금액이 리워드 가격보다 적습니다.");
     }
 

--- a/src/test/java/kpl/fiml/sponsor/domain/SponsorTest.java
+++ b/src/test/java/kpl/fiml/sponsor/domain/SponsorTest.java
@@ -2,6 +2,7 @@ package kpl.fiml.sponsor.domain;
 
 import kpl.fiml.project.domain.Reward;
 import kpl.fiml.sponsor.exception.InvalidTotalAmountException;
+import kpl.fiml.sponsor.exception.SponsorErrorCode;
 import kpl.fiml.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ public class SponsorTest {
         // when-then
         assertThatThrownBy(() -> Sponsor.builder().user(user).reward(reward).totalAmount(totalAmount).build())
                 .isInstanceOf(InvalidTotalAmountException.class)
-                .hasMessageContaining("후원 금액이 리워드 가격보다 적습니다.");
+                .hasMessageContaining(SponsorErrorCode.INVALID_TOTAL_AMOUNT.getMessage());
     }
 
 }

--- a/src/test/java/kpl/fiml/sponsor/domain/SponsorTest.java
+++ b/src/test/java/kpl/fiml/sponsor/domain/SponsorTest.java
@@ -1,0 +1,34 @@
+package kpl.fiml.sponsor.domain;
+
+import kpl.fiml.project.domain.Reward;
+import kpl.fiml.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class SponsorTest {
+
+    @Test
+    @DisplayName("후원 생성 시 리워드 가격보다 적은 후원 금액은 예외를 발생시킨다.")
+    void testInvalidTotalAmountException() {
+        // given
+        User user = User.builder()
+                .email("abc@gmail.com")
+                .contact("01012345678")
+                .build();
+        Reward reward = Reward.builder()
+                .quantityLimited(false)
+                .maxPurchaseQuantity(100000)
+                .price(50000L)
+                .build();
+
+        Long totalAmount = 49999L;
+
+        // when-then
+        assertThatThrownBy(() -> Sponsor.builder().user(user).reward(reward).totalAmount(totalAmount).build())
+                .isInstanceOf(IllegalArgumentException.class) // TODO 커스텀 예외 생성 시 변경 필요
+                .hasMessageContaining("후원 금액이 리워드 가격보다 적습니다.");
+    }
+
+}

--- a/src/test/java/kpl/fiml/sponsor/presentation/SponsorControllerTest.java
+++ b/src/test/java/kpl/fiml/sponsor/presentation/SponsorControllerTest.java
@@ -2,6 +2,7 @@ package kpl.fiml.sponsor.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kpl.fiml.customMockUser.WithCustomMockUser;
+import kpl.fiml.sponsor.domain.SponsorStatus;
 import kpl.fiml.sponsor.dto.request.SponsorCreateRequest;
 import kpl.fiml.sponsor.dto.request.SponsorUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +58,7 @@ public class SponsorControllerTest {
                 .andExpect(jsonPath("$.[0].userId").value(1))
                 .andExpect(jsonPath("$.[0].rewardId").value(1))
                 .andExpect(jsonPath("$.[0].totalAmount").value(60000))
-                .andExpect(jsonPath("$.[0].sponsorStatus").value("펀딩 진행 중"));
+                .andExpect(jsonPath("$.[0].sponsorStatus").value(SponsorStatus.FUNDING_PROCEEDING.getDisplayName()));
     }
 
     @Test
@@ -70,7 +71,7 @@ public class SponsorControllerTest {
                 .andExpect(jsonPath("$.[0].userId").value(1))
                 .andExpect(jsonPath("$.[0].rewardId").value(1))
                 .andExpect(jsonPath("$.[0].totalAmount").value(60000))
-                .andExpect(jsonPath("$.[0].sponsorStatus").value("펀딩 진행 중"));
+                .andExpect(jsonPath("$.[0].sponsorStatus").value(SponsorStatus.FUNDING_PROCEEDING.getDisplayName()));
     }
 
     @Test
@@ -95,7 +96,7 @@ public class SponsorControllerTest {
                 .andExpect(jsonPath("$.userId").value(1))
                 .andExpect(jsonPath("$.rewardId").value(1))
                 .andExpect(jsonPath("$.totalAmount").value(70000))
-                .andExpect(jsonPath("$.sponsorStatus").value("펀딩 진행 중"));
+                .andExpect(jsonPath("$.sponsorStatus").value(SponsorStatus.FUNDING_PROCEEDING.getDisplayName()));
     }
 
     @Test

--- a/src/test/java/kpl/fiml/sponsor/presentation/SponsorControllerTest.java
+++ b/src/test/java/kpl/fiml/sponsor/presentation/SponsorControllerTest.java
@@ -1,0 +1,111 @@
+package kpl.fiml.sponsor.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kpl.fiml.customMockUser.WithCustomMockUser;
+import kpl.fiml.sponsor.dto.request.SponsorCreateRequest;
+import kpl.fiml.sponsor.dto.request.SponsorUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.Field;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SponsorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("후원 정보를 생성할 수 있다.")
+    public void testCreateSponsor() throws Exception {
+        // given
+        SponsorCreateRequest request = new SponsorCreateRequest();
+        Field rewardId = request.getClass().getDeclaredField("rewardId");
+        rewardId.setAccessible(true);
+        rewardId.set(request, 1L);
+        Field totalAmount = request.getClass().getDeclaredField("totalAmount");
+        totalAmount.setAccessible(true);
+        totalAmount.set(request, 60000L);
+
+        // when-then
+        mockMvc.perform(post("/api/v1/sponsors")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.id").isNotEmpty());
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("특정 회원의 후원 리스트를 조회할 수 있다.")
+    public void testGetSponsorsByUser() throws Exception {
+        mockMvc.perform(get("/api/v1/sponsors"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.[0].userId").value(1))
+                .andExpect(jsonPath("$.[0].rewardId").value(1))
+                .andExpect(jsonPath("$.[0].totalAmount").value(60000))
+                .andExpect(jsonPath("$.[0].sponsorStatus").value("펀딩 진행 중"));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("특정 프로젝트의 후원 리스트를 조회할 수 있다.")
+    public void testGetSponsorsByProject() throws Exception {
+        mockMvc.perform(get("/api/v1/sponsors/project/{projectId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.[0].userId").value(1))
+                .andExpect(jsonPath("$.[0].rewardId").value(1))
+                .andExpect(jsonPath("$.[0].totalAmount").value(60000))
+                .andExpect(jsonPath("$.[0].sponsorStatus").value("펀딩 진행 중"));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("후원 정보를 수정할 수 있다.")
+    public void testUpdateSponsor() throws Exception {
+        // given
+        SponsorUpdateRequest request = new SponsorUpdateRequest();
+        Field rewardId = request.getClass().getDeclaredField("rewardId");
+        rewardId.setAccessible(true);
+        rewardId.set(request, 1L);
+        Field totalAmount = request.getClass().getDeclaredField("totalAmount");
+        totalAmount.setAccessible(true);
+        totalAmount.set(request, 70000L);
+
+        // when-then
+        mockMvc.perform(patch("/api/v1/sponsors/{sponsorId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.rewardId").value(1))
+                .andExpect(jsonPath("$.totalAmount").value(70000))
+                .andExpect(jsonPath("$.sponsorStatus").value("펀딩 진행 중"));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("후원을 취소할 수 있다.")
+    public void testDeleteSponsor() throws Exception {
+        mockMvc.perform(delete("/api/v1/sponsors/{sponsorId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.deleteAt").isNotEmpty());
+    }
+}


### PR DESCRIPTION
- 후원 수정/삭제에서 누락된 로직 추가
- 후원 도메인 테스트
- 후원 서비스 테스트
- 후원 컨트롤러 테스트
  - 테스트에서 AuthenticationPrincipal 주입 위한 커스텀 MockUser 구현
- 후원에서 필요한 커스텀 예외 구현

후원쪽이 기능이 많아서 성공 케이스 위주로 작성했는데도 코드가 깁니다... 추후에 실패 케이스 테스트 추가할 것 같습니다