### PR TITLE
67 user 단위테스트 작성

### DIFF
--- a/src/main/java/kpl/fiml/user/application/UserService.java
+++ b/src/main/java/kpl/fiml/user/application/UserService.java
@@ -13,10 +13,7 @@ import kpl.fiml.user.dto.response.LoginResponse;
 import kpl.fiml.user.dto.response.UserCreateResponse;
 import kpl.fiml.user.dto.response.UserDeleteResponse;
 import kpl.fiml.user.dto.response.UserUpdateResponse;
-import kpl.fiml.user.exception.DuplicateEmailException;
-import kpl.fiml.user.exception.EmailNotFoundException;
-import kpl.fiml.user.exception.PasswordMismatchException;
-import kpl.fiml.user.exception.UserErrorCode;
+import kpl.fiml.user.exception.*;
 import kpl.fiml.user.vo.PasswordVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -98,7 +95,7 @@ public class UserService {
 
     private void validateUserAccess(User loginUser, User targetUser) {
         if(!targetUser.isSameUser(loginUser)) {
-            throw new IllegalArgumentException("User 정보 조회 권한이 없습니다.");
+            throw new UserPermissionException(UserErrorCode.ACCESS_DENIED);
         }
     }
 

--- a/src/main/java/kpl/fiml/user/domain/User.java
+++ b/src/main/java/kpl/fiml/user/domain/User.java
@@ -52,10 +52,10 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "cash", nullable = false)
     private Long cash;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     private List<String> roles = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Project> projectList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/kpl/fiml/user/domain/UserRepository.java
+++ b/src/main/java/kpl/fiml/user/domain/UserRepository.java
@@ -10,10 +10,10 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.projectList WHERE u.id = :userId AND u.deletedAt IS NULL")
-    Optional<User> findByIdAndDeletedAtIsNull(@Param("userId") Long id);
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
 
-    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.roles WHERE u.email = :email AND u.deletedAt IS NULL")
+    Optional<User> findByEmailAndDeletedAtIsNull(@Param("email") String email);
 
     boolean existsByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/kpl/fiml/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/kpl/fiml/user/dto/request/UserUpdateRequest.java
@@ -1,9 +1,11 @@
 package kpl.fiml.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class UserUpdateRequest {
     @NotBlank(message = "이름은 필수 입력값입니다.")
     private String name;

--- a/src/main/java/kpl/fiml/user/exception/InvalidContactException.java
+++ b/src/main/java/kpl/fiml/user/exception/InvalidContactException.java
@@ -1,0 +1,14 @@
+package kpl.fiml.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidContactException extends RuntimeException {
+
+    private final String errorCode;
+
+    public InvalidContactException(UserErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/kpl/fiml/user/exception/UserErrorCode.java
+++ b/src/main/java/kpl/fiml/user/exception/UserErrorCode.java
@@ -14,7 +14,8 @@ public enum UserErrorCode {
     PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다."),
     ACCESS_DENIED("User 접근 권한이 없습니다."),
     INVALID_AMOUNT("금액은 음수가 될 수 없습니다."),
-    CASH_NOT_ENOUGH("보유 현금이 부족합니다.");
+    CASH_NOT_ENOUGH("보유 현금이 부족합니다."),
+    INVALID_CONTACT("전화번호 형식이 유효하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/kpl/fiml/user/exception/UserGlobalExceptionHandler.java
+++ b/src/main/java/kpl/fiml/user/exception/UserGlobalExceptionHandler.java
@@ -58,4 +58,11 @@ public class UserGlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(InvalidContactException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleInvalidContactException(InvalidContactException e) {
+        ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/kpl/fiml/user/vo/ContactVo.java
+++ b/src/main/java/kpl/fiml/user/vo/ContactVo.java
@@ -1,5 +1,7 @@
 package kpl.fiml.user.vo;
 
+import kpl.fiml.user.exception.InvalidContactException;
+import kpl.fiml.user.exception.UserErrorCode;
 import lombok.Getter;
 
 @Getter
@@ -10,7 +12,7 @@ public class ContactVo {
 
     public ContactVo(String contact) {
         if (!isValidContact(contact)) {
-            throw new IllegalArgumentException("유효하지 않은 전화번호 형식입니다.");
+            throw new InvalidContactException(UserErrorCode.INVALID_CONTACT);
         }
         this.contact = contact;
     }

--- a/src/test/java/kpl/fiml/TestDataFactory.java
+++ b/src/test/java/kpl/fiml/TestDataFactory.java
@@ -19,7 +19,7 @@ public class TestDataFactory {
     public static User generateUserWithId(Long id) {
         User user = User.builder()
                 .email("email@email.com")
-                .encryptPassword("encryptPassword")
+                .encryptPassword("encryptPassword!")
                 .name("name")
                 .bio("bio")
                 .contact("01012345678")

--- a/src/test/java/kpl/fiml/user/application/UserServiceTest.java
+++ b/src/test/java/kpl/fiml/user/application/UserServiceTest.java
@@ -174,4 +174,26 @@ public class UserServiceTest {
         verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
         verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(loginUserId);
     }
+
+    @Test
+    @DisplayName("사용자 삭제 실패 : 접근 권한 없음")
+    void testDeleteById_Fail_AccessDenied() {
+        // Given
+        Long userId = 1L;
+        Long loginUserId = 2L;
+        User fakeUser = TestDataFactory.generateUserWithId(userId);
+        User loginUser = TestDataFactory.generateUserWithId(loginUserId);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.ofNullable(fakeUser));
+        when(userRepository.findByIdAndDeletedAtIsNull(loginUserId)).thenReturn(Optional.ofNullable(loginUser));
+
+        // When/Then
+        assertThrows(UserPermissionException.class, () -> userService.deleteById(userId, loginUserId));
+
+        // verify
+        verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
+        verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(loginUserId);
+        assert fakeUser != null;
+        verify(userRepository, never()).delete(fakeUser);
+    }
 }

--- a/src/test/java/kpl/fiml/user/application/UserServiceTest.java
+++ b/src/test/java/kpl/fiml/user/application/UserServiceTest.java
@@ -130,6 +130,7 @@ public class UserServiceTest {
     }
 
     @Test
+    @DisplayName("user update 실패 : 잘못된 비밀번호 형식")
     void testUpdateUser_Fail_PasswordValidation() {
         // Given
         Long userId = 1L;

--- a/src/test/java/kpl/fiml/user/domain/UserTest.java
+++ b/src/test/java/kpl/fiml/user/domain/UserTest.java
@@ -1,8 +1,10 @@
 package kpl.fiml.user.domain;
 
 import kpl.fiml.TestDataFactory;
-import kpl.fiml.user.exception.CashNotEnoughException;
-import kpl.fiml.user.exception.InvalidAmountException;
+import kpl.fiml.user.exception.*;
+import kpl.fiml.user.vo.ContactVo;
+import kpl.fiml.user.vo.EmailVo;
+import kpl.fiml.user.vo.PasswordVo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -59,4 +61,62 @@ class UserTest {
         assertThrows(CashNotEnoughException.class, () -> user.decreaseCash(100L), "캐시 부족으로 인해 예외가 발생해야 합니다.");
     }
 
+    @Test
+    @DisplayName("사용자 정보 업데이트 성공: 유효한 업데이트")
+    void testUpdateUser_Success_ValidUpdate() {
+        // Given
+        User user = TestDataFactory.generateUserWithId(1L);
+
+        // When
+        user.updateUser(user, "Updated Name", "Updated Bio", "new-image.jpg", "update@example.com", "newpassword123!", "0101234567");
+
+        // Then
+        assertEquals("Updated Name", user.getName(), "사용자 이름이 정상적으로 업데이트되었어야 합니다.");
+        assertEquals("Updated Bio", user.getBio(), "사용자 Bio가 정상적으로 업데이트되었어야 합니다.");
+        assertEquals("new-image.jpg", user.getProfileImage(), "프로필 이미지가 정상적으로 업데이트되었어야 합니다.");
+        assertEquals("update@example.com", user.getEmail(), "이메일이 정상적으로 업데이트되었어야 합니다.");
+        assertEquals("newpassword123!", user.getPassword(), "비밀번호가 정상적으로 업데이트되었어야 합니다.");
+        assertEquals("0101234567", user.getContact(), "연락처가 정상적으로 업데이트되었어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("사용자 정보 업데이트 실패: 접근 권한 없음")
+    void testUpdateUser_Fail_AccessDenied() {
+        // Given
+        User user = TestDataFactory.generateUserWithId(1L);
+        User loginUser = TestDataFactory.generateUserWithId(2L);
+
+        // When/Then
+        assertThrows(UserPermissionException.class, () -> user.updateUser(loginUser, "Updated Name", "Updated Bio", "new-image.jpg", "update@example.com", "newpassword123!", "0101234567"), "접근 권한이 없어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("연락처 생성 실패 : 특수문자 포함 불가")
+    void testInvalidContact_Fail_SpecialCharacters() {
+        // Given
+        String invalidContact = "010-1234-5678";
+
+        // When/Then
+        assertThrows(InvalidContactException.class, () -> new ContactVo(invalidContact), "특수 문자가 포함된 연락처는 예외를 발생시켜야 합니다.");
+    }
+
+    @Test
+    @DisplayName("이메일 생성 실패 : 유효하지 않은 이메일 형식")
+    void testInvalidEmail_Fail_InvalidFormat() {
+        // Given
+        String invalidEmail = "invalid-email";
+
+        // When/Then
+        assertThrows(InvalidEmailException.class, () -> new EmailVo(invalidEmail), "유효하지 않은 이메일 형식은 예외를 발생시켜야 합니다.");
+    }
+
+    @Test
+    @DisplayName("비밀번호 생성 실패 : 유효하지 않은 비밀번호")
+    void testInvalidPassword_Fail_NoSpecialCharacters() {
+        // Given
+        String invalidPassword = "NoSpecial123";
+
+        // When/Then
+        assertThrows(InvalidPasswordException.class, () -> new PasswordVo(invalidPassword), "특수 문자를 포함하지 않은 비밀번호는 예외를 발생시켜야 합니다.");
+    }
 }

--- a/src/test/java/kpl/fiml/user/domain/UserTest.java
+++ b/src/test/java/kpl/fiml/user/domain/UserTest.java
@@ -1,0 +1,38 @@
+package kpl.fiml.user.domain;
+
+import kpl.fiml.TestDataFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+    @Test
+    @DisplayName("사용자 캐시 증가 성공")
+    void testIncreaseCash_Success_ValidAmount() {
+        // Given
+        User user = TestDataFactory.generateUserWithId(1L);
+
+        // When
+        user.increaseCash(100L);
+
+        // Then
+        assertEquals(100L, user.getCash());
+    }
+
+    @Test
+    @DisplayName("사용자 캐시 감소 성공: 유효한 금액")
+    void testDecreaseCash_Success_ValidAmount() {
+        // Given
+        User user = TestDataFactory.generateUserWithId(1L);
+        ReflectionTestUtils.setField(user, "cash", 200L);
+
+        // When
+        user.decreaseCash(100L);
+
+        // Then
+        assertEquals(100L, user.getCash());
+    }
+}

--- a/src/test/java/kpl/fiml/user/domain/UserTest.java
+++ b/src/test/java/kpl/fiml/user/domain/UserTest.java
@@ -1,6 +1,8 @@
 package kpl.fiml.user.domain;
 
 import kpl.fiml.TestDataFactory;
+import kpl.fiml.user.exception.CashNotEnoughException;
+import kpl.fiml.user.exception.InvalidAmountException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -10,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UserTest {
 
     @Test
-    @DisplayName("사용자 캐시 증가 성공")
+    @DisplayName("사용자 캐시 증가 성공: 유효한 금액")
     void testIncreaseCash_Success_ValidAmount() {
         // Given
         User user = TestDataFactory.generateUserWithId(1L);
@@ -35,4 +37,26 @@ class UserTest {
         // Then
         assertEquals(100L, user.getCash());
     }
+
+    @Test
+    @DisplayName("사용자 캐시 감소 실패: 부적절한 금액")
+    void testDecreaseCash_Fail_InvalidAmount() {
+        // Given
+        User user = TestDataFactory.generateUserWithId(1L);
+
+        // When/Then
+        assertThrows(InvalidAmountException.class, () -> user.decreaseCash(-100L), "부적절한 금액으로 인해 예외가 발생해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("사용자 캐시 감소 실패: 캐시 부족")
+    void testDecreaseCash_Fail_NotEnoughCash() {
+        // Given
+        User user = TestDataFactory.generateUserWithId(1L);
+        ReflectionTestUtils.setField(user, "cash", 50L);
+
+        // When/Then
+        assertThrows(CashNotEnoughException.class, () -> user.decreaseCash(100L), "캐시 부족으로 인해 예외가 발생해야 합니다.");
+    }
+
 }


### PR DESCRIPTION
- User Service 계층 실패 관련 테스트 작성
- User Domain 테스트 작성
- User Custom Exception 누락 : InvalidContactException 추가 및 적용

- User 조회 fetch join 재적용 : [User.java](src/main/java/kpl/fiml/user/domain/User.java) , [UserRepository.java](src/main/java/kpl/fiml/user/domain/UserRepository.java) User 조회시 user role 조회 쿼리 발생 fetchType LAZY 설정 안되어 있던 부분 설정했습니다 / email로 조회 시에는 security 코드가 실행되면서 role 조회 필수로 필요로 해 JPQL fetch join 적용했습니다.